### PR TITLE
Add validation to reject Pie keywords as variable names

### DIFF
--- a/src/pie-interpreter/__tests__/test-parser.ts
+++ b/src/pie-interpreter/__tests__/test-parser.ts
@@ -180,3 +180,56 @@ describe("Inductive Types Parser", () => {
     expect(() => testParser(input)).not.toThrow();
   });
 })
+
+describe("Keyword as variable name rejection", () => {
+  it("should reject 'zero' as a variable name in claim", () => {
+    const input = `(claim zero Nat)`;
+    expect(() => testParser(input)).toThrow("'zero' is a keyword and cannot be used as a variable name");
+  });
+
+  it("should reject 'zero' as a variable name in define", () => {
+    const input = `(define zero zero)`;
+    expect(() => testParser(input)).toThrow("'zero' is a keyword and cannot be used as a variable name");
+  });
+
+  it("should reject 'add1' as a variable name in claim", () => {
+    const input = `(claim add1 (-> Nat Nat))`;
+    expect(() => testParser(input)).toThrow("'add1' is a keyword and cannot be used as a variable name");
+  });
+
+  it("should reject 'Nat' as a variable name in claim", () => {
+    const input = `(claim Nat U)`;
+    expect(() => testParser(input)).toThrow("'Nat' is a keyword and cannot be used as a variable name");
+  });
+
+  it("should reject 'lambda' as a variable name in define", () => {
+    const input = `(define lambda (lambda (x) x))`;
+    // 'lambda' is caught by scheme parser as a syntax error
+    expect(() => testParser(input)).toThrow();
+  });
+
+  it("should reject 'nil' as a variable name in claim", () => {
+    const input = `(claim nil (List Nat))`;
+    expect(() => testParser(input)).toThrow("'nil' is a keyword and cannot be used as a variable name");
+  });
+
+  it("should reject 'cons' as a variable name in define", () => {
+    const input = `(define cons (cons zero nil))`;
+    expect(() => testParser(input)).toThrow("'cons' is a keyword and cannot be used as a variable name");
+  });
+
+  it("should reject 'the' as a variable name in claim", () => {
+    const input = `(claim the (-> U U U))`;
+    expect(() => testParser(input)).toThrow("'the' is a keyword and cannot be used as a variable name");
+  });
+
+  it("should allow valid variable names", () => {
+    const input = `(claim myZero Nat)`;
+    expect(() => testParser(input)).not.toThrow();
+  });
+
+  it("should allow valid variable names with numbers", () => {
+    const input = `(claim zero1 Nat)`;
+    expect(() => testParser(input)).not.toThrow();
+  });
+})

--- a/src/pie-interpreter/parser/parser.ts
+++ b/src/pie-interpreter/parser/parser.ts
@@ -637,16 +637,24 @@ export class pieDeclarationParser {
     const parsee = getValue(ast);
     if (parsee === 'claim') {
       const elements = (ast as Extended.List).elements;
+      const name = getValue(elements[1] as Element);
+      if (!isVarName(name)) {
+        throw new Error(`'${name}' is a keyword and cannot be used as a variable name`);
+      }
       return new Claim(
         syntaxToLocation(elementToSyntax(elements[0] as Element, ast.location)),
-        getValue(elements[1] as Element),
+        name,
         Parser.parseElements(elements[2] as Element)
       );
     } else if (parsee === 'define') {
       const elements = (ast as Extended.List).elements;
+      const name = getValue(elements[1] as Element);
+      if (!isVarName(name)) {
+        throw new Error(`'${name}' is a keyword and cannot be used as a variable name`);
+      }
       return new Definition(
         syntaxToLocation(elementToSyntax(elements[0] as Element, ast.location)),
-        getValue(elements[1] as Element),
+        name,
         Parser.parseElements(elements[2] as Element)
       );
     } else if (parsee === 'check-same') {
@@ -659,9 +667,13 @@ export class pieDeclarationParser {
       );
     } else if (parsee === 'define-tactically') {
       const elements = (ast as Extended.List).elements;
+      const name = getValue(elements[1] as Element);
+      if (!isVarName(name)) {
+        throw new Error(`'${name}' is a keyword and cannot be used as a variable name`);
+      }
       return new DefineTactically(
         syntaxToLocation(elementToSyntax(elements[0] as Element, ast.location)),
-        getValue(elements[1] as Element),
+        name,
         (elements[2] as Extended.List).elements.map((x: Expression) => Parser.parseToTactics(x as Element))
       );
     } else if (parsee === 'data') {

--- a/src/standalone.ts
+++ b/src/standalone.ts
@@ -5,11 +5,11 @@ console.log("Pie Interpreter - Standalone Mode");
 
 // Test with a simple Pie expression
 const testCode = `
-(claim zero Nat)
-(define zero zero)
+(claim myZero Nat)
+(define myZero zero)
 
 (claim one Nat) 
-(define one (add1 zero))
+(define one (add1 myZero))
 
 (claim two Nat)
 (define two (add1 one))


### PR DESCRIPTION
Pie keywords (zero, add1, Nat, lambda, nil, etc.) should not be allowed as variable names in claim, define, and define-tactically declarations.

Changes:
- Add isVarName validation in pieDeclarationParser for claim, define, and define-tactically to reject keywords as variable names
- Update test example in standalone.ts to use 'myZero' instead of 'zero'
- Add comprehensive test suite with 10 test cases covering keyword rejection and valid variable name acceptance

Fixes issue where keywords could be incorrectly used as variable names, potentially causing confusion between user-defined variables and language keywords.