### PR TITLE
Improve canvas layout and UI polish

### DIFF
--- a/web-react/index.html
+++ b/web-react/index.html
@@ -5,6 +5,9 @@
     <link rel="icon" type="image/svg+xml" href="/vite.svg" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
     <title>Pie Proof Editor</title>
+    <link rel="preconnect" href="https://fonts.googleapis.com" />
+    <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin />
+    <link href="https://fonts.googleapis.com/css2?family=Inter:wght@400;500;600;700&family=JetBrains+Mono:wght@400;500;600&display=swap" rel="stylesheet" />
   </head>
   <body>
     <div id="root"></div>

--- a/web-react/package.json
+++ b/web-react/package.json
@@ -12,6 +12,7 @@
     "test:watch": "vitest"
   },
   "dependencies": {
+    "@dagrejs/dagre": "^3.0.0",
     "@google/genai": "^1.25.0",
     "@monaco-editor/react": "^4.6.0",
     "@radix-ui/react-dialog": "^1.1.4",
@@ -40,11 +41,11 @@
     "@types/react-dom": "^18.3.5",
     "@vitejs/plugin-react": "^4.3.4",
     "autoprefixer": "^10.4.20",
+    "jsdom": "^25.0.0",
     "postcss": "^8.4.49",
     "tailwindcss": "^3.4.17",
     "typescript": "~5.6.2",
     "vite": "^6.0.7",
-    "vitest": "^3.0.0",
-    "jsdom": "^25.0.0"
+    "vitest": "^3.0.0"
   }
 }

--- a/web-react/src/app/App.tsx
+++ b/web-react/src/app/App.tsx
@@ -140,15 +140,10 @@ function AppContent() {
         )}
 
         <div className="pe-tb-right">
-          {displayError ? (
+          {displayError && (
             <span className="pe-error-pill">
               <span style={{ width: 6, height: 6, borderRadius: 3, background: 'var(--pe-err)', flexShrink: 0 }} />
               {displayError.length > 60 ? displayError.slice(0, 60) + '…' : displayError}
-            </span>
-          ) : (
-            <span className="pe-auto-indicator" title="Source and canvas stay in sync automatically">
-              <span className="pe-pulse" />
-              Auto-sync on
             </span>
           )}
         </div>
@@ -167,10 +162,6 @@ function AppContent() {
           <svg width="14" height="14" viewBox="0 0 14 14" fill="none" stroke="currentColor" strokeWidth="1.6" strokeLinecap="round">
             <path d="M5 3l3 4-3 4" />
           </svg>
-          <span className="pe-stub-label">Source</span>
-          <span className="pe-stub-sync">
-            <span style={{ display: 'block', width: 6, height: 6, borderRadius: 3, background: hasSession ? 'var(--pe-ok)' : 'var(--pe-faint)' }} />
-          </span>
         </button>
 
         {/* Source rail */}
@@ -190,10 +181,6 @@ function AppContent() {
           <div className="pe-canvas-head">
             <div className="pe-breadcrumb">
               <span>proof</span>
-              <svg width="10" height="10" viewBox="0 0 10 10" fill="none" stroke="#aaa" strokeWidth="1.6">
-                <path d="M3.5 2l3 3-3 3" />
-              </svg>
-              <span className="cur">{activeClaimName || '—'}</span>
               {openGoals > 0 && (
                 <>
                   <svg width="10" height="10" viewBox="0 0 10 10" fill="none" stroke="#aaa" strokeWidth="1.6">
@@ -205,18 +192,6 @@ function AppContent() {
             </div>
             <div style={{ flex: 1 }} />
             <div className="pe-canvas-actions">
-              <button className="pe-icon-btn" title="Auto-layout" id="pe-canvas-autolayout">
-                <svg width="13" height="13" viewBox="0 0 13 13" fill="none" stroke="currentColor" strokeWidth="1.5">
-                  <rect x="1" y="1" width="4" height="4" /><rect x="8" y="1" width="4" height="4" />
-                  <rect x="4.5" y="8" width="4" height="4" />
-                  <path d="M3 5v1.5h6.5V5M6.5 6.5V8" />
-                </svg>
-              </button>
-              <button className="pe-icon-btn" title="Fit view" id="pe-canvas-fit">
-                <svg width="13" height="13" viewBox="0 0 13 13" fill="none" stroke="currentColor" strokeWidth="1.5" strokeLinecap="round">
-                  <path d="M1 4V1h3M12 4V1H9M1 9v3h3M12 9v3H9" />
-                </svg>
-              </button>
               <button
                 className="pe-icon-btn"
                 title="AI Hints settings"
@@ -236,24 +211,6 @@ function AppContent() {
             <ProofCanvas />
           </div>
 
-          <div className="pe-canvas-status">
-            {hasSession ? (
-              <>
-                <span className="pe-cs-item">
-                  <span className="pe-cs-dot" />
-                  {nodes.length} nodes · {edges.length} edges
-                </span>
-                {openGoals > 0 && (
-                  <span className="pe-cs-item">{openGoals} open goal{openGoals !== 1 ? 's' : ''}</span>
-                )}
-                {appliedTactics > 0 && (
-                  <span className="pe-cs-item">{appliedTactics} applied tactic{appliedTactics !== 1 ? 's' : ''}</span>
-                )}
-              </>
-            ) : (
-              <span className="pe-cs-item" style={{ color: 'var(--pe-faint)' }}>No active session · select an example or start a proof</span>
-            )}
-          </div>
         </section>
 
         {/* Detail rail */}

--- a/web-react/src/app/App.tsx
+++ b/web-react/src/app/App.tsx
@@ -4,7 +4,6 @@ import { ProofCanvas } from '@/features/proof-editor/components/ProofCanvas';
 import { DetailPanel } from '@/features/proof-editor/components/panels/DetailPanel';
 import { TacticPalette } from '@/features/proof-editor/components/panels/TacticPalette';
 import { SourceCodePanel } from '@/features/proof-editor/components/panels/SourceCodePanel';
-import { DefinitionsPanel } from '@/features/proof-editor/components/panels/DefinitionsPanel';
 import { AISettingsPanel } from '@/features/proof-editor/components/panels/AISettingsPanel';
 import { useProofSession } from '@/features/proof-editor/hooks/useProofSession';
 import { useKeyboardShortcuts } from '@/features/proof-editor/hooks/useKeyboardShortcuts';
@@ -13,19 +12,26 @@ import { useExampleStore } from '@/features/proof-editor/store/example-store';
 import { useMetadataStore } from '@/features/proof-editor/store/metadata-store';
 import { setApplyTacticCallback, type ApplyTacticOptions } from '@/features/proof-editor/utils/tactic-callback';
 import { EXAMPLES } from '@/features/proof-editor/data/examples';
-import { ProofPicker } from '@/features/proof-editor/components/ProofPicker';
-import type { GlobalEntry } from '@pie/protocol';
+
+function readSourceCollapsed(): boolean {
+  try { return localStorage.getItem('pie.sourceCollapsed') === '1'; } catch { return false; }
+}
+
+function writeSourceCollapsed(v: boolean) {
+  try { localStorage.setItem('pie.sourceCollapsed', v ? '1' : '0'); } catch {}
+}
 
 function AppContent() {
-  const { applyTactic, error } = useProofSession();
+  const { applyTactic, error, hasActiveSession } = useProofSession();
   const updateNode = useProofStore((s) => s.updateNode);
   const nodes = useProofStore((s) => s.nodes);
+  const edges = useProofStore((s) => s.edges);
   const setManualPosition = useProofStore((s) => s.setManualPosition);
+  const activeClaimName = useProofStore((s) => s.claimName);
+  const sessionId = useProofStore((s) => s.sessionId);
   const [tacticError, setTacticError] = useState<string | null>(null);
-  const [definitionsPanelCollapsed, setDefinitionsPanelCollapsed] = useState(false);
-  const [foundClaims, setFoundClaims] = useState<GlobalEntry[]>([]);
-  const [foundTheorems, setFoundTheorems] = useState<GlobalEntry[]>([]);
-  const [selectedProof, setSelectedProof] = useState<string | null>(null);
+  const [sourceCollapsed, setSourceCollapsed] = useState(readSourceCollapsed);
+  const [aiPanelOpen, setAiPanelOpen] = useState(false);
 
   // Use keyboard shortcuts hook
   useKeyboardShortcuts();
@@ -34,69 +40,55 @@ function AppContent() {
   const selectedExample = useExampleStore((s) => s.selectedExample);
   const selectExample = useExampleStore((s) => s.selectExample);
 
-  // Use metadata store for global context
+  // Use metadata store for global context (passed to DetailPanel)
   const globalContext = useMetadataStore((s) => s.globalContext);
+
+  const handleCollapseSource = useCallback(() => {
+    setSourceCollapsed(true);
+    writeSourceCollapsed(true);
+  }, []);
+
+  const handleExpandSource = useCallback(() => {
+    setSourceCollapsed(false);
+    writeSourceCollapsed(false);
+  }, []);
 
   // Set up the global callback for tactic application
   const handleApplyTactic = useCallback(async (options: ApplyTacticOptions) => {
     const { goalId, tacticType, params, tacticNodeId } = options;
-    console.log('[App] Applying tactic:', tacticType, 'to goal:', goalId, 'params:', params, 'tacticNodeId:', tacticNodeId);
     setTacticError(null);
 
-    // Transfer tactic node position to the new tactic ID before sync
-    // The new tactic will be created with ID "tactic-for-{goalId}"
     if (tacticNodeId) {
       const tacticNode = nodes.find(n => n.id === tacticNodeId);
       if (tacticNode) {
         const newTacticId = `tactic-for-${goalId}`;
-        console.log(`[App] Transferring position from ${tacticNodeId} to ${newTacticId}:`, tacticNode.position);
         setManualPosition(newTacticId, { ...tacticNode.position });
       }
     }
 
     try {
       const result = await applyTactic(goalId, tacticType, params);
-
-      if (result.success) {
-        // Success: syncFromWorker already called in useProofSession
-        // The proof tree will be updated with new goals
-        console.log('[App] Tactic succeeded');
-      } else {
-        // Failure: update tactic node with error status
+      if (!result.success) {
         const errorMsg = result.error || 'Tactic application failed';
         setTacticError(errorMsg);
-        console.error('[App] Tactic failed:', errorMsg);
-
-        // If we have a tactic node ID, update its status to error
         if (tacticNodeId) {
-          updateNode(tacticNodeId, {
-            status: 'error',
-            errorMessage: errorMsg,
-          });
+          updateNode(tacticNodeId, { status: 'error', errorMessage: errorMsg });
         }
       }
     } catch (e) {
       const errorMsg = e instanceof Error ? e.message : String(e);
       setTacticError(errorMsg);
-      console.error('[App] Tactic error:', e);
-
-      // If we have a tactic node ID, update its status to error
       if (tacticNodeId) {
-        updateNode(tacticNodeId, {
-          status: 'error',
-          errorMessage: errorMsg,
-        });
+        updateNode(tacticNodeId, { status: 'error', errorMessage: errorMsg });
       }
     }
   }, [applyTactic, updateNode, nodes, setManualPosition]);
 
-  // Register the callback when component mounts
   useEffect(() => {
     setApplyTacticCallback(handleApplyTactic);
     return () => setApplyTacticCallback(null);
   }, [handleApplyTactic]);
 
-  // Clear tactic error after a delay
   useEffect(() => {
     if (tacticError) {
       const timer = setTimeout(() => setTacticError(null), 5000);
@@ -104,59 +96,204 @@ function AppContent() {
     }
   }, [tacticError]);
 
-  return (
-    <div className="flex h-screen w-screen flex-col">
-      <header className="flex h-12 items-center border-b px-4 gap-4">
-        <h1 className="text-lg font-semibold">Pie Proof Editor</h1>
+  const hasSession = Boolean(sessionId) || hasActiveSession;
+  const openGoals = nodes.filter(n => n.type === 'goal' && (n.data as { status?: string }).status !== 'completed').length;
+  const appliedTactics = nodes.filter(n => n.type === 'tactic' && (n.data as { status?: string }).status === 'applied').length;
+  const displayError = tacticError || error;
 
-        {/* Example dropdown */}
-        <div className="flex items-center gap-2">
-          <label htmlFor="example-select" className="text-sm text-muted-foreground">
-            Load Example:
-          </label>
+  return (
+    <div className="pe-app">
+
+      {/* ============ TOP BAR ============ */}
+      <header className="pe-topbar">
+        <div className="pe-brand">
+          <span className="pe-brand-pi">π</span>
+          <span className="pe-brand-name">Pie</span>
+          <span className="pe-brand-sub">· Proof Editor</span>
+        </div>
+
+        <div className="pe-sep" />
+
+        <div style={{ display: 'flex', alignItems: 'center', gap: 6 }}>
+          <span className="pe-tb-label">Example</span>
           <select
-            id="example-select"
+            className="pe-select"
             value={selectedExample}
             onChange={(e) => selectExample(e.target.value)}
-            className="rounded border bg-background px-2 py-1 text-sm focus:outline-none focus:ring-2 focus:ring-primary h-8"
           >
             <option value="">-- Select --</option>
             {EXAMPLES.map((ex) => (
-              <option key={ex.id} value={ex.id}>
-                {ex.name}
-              </option>
+              <option key={ex.id} value={ex.id}>{ex.name}</option>
             ))}
           </select>
         </div>
 
-        {/* Show tactic error in header */}
-        {(tacticError || error) && (
-          <div className="ml-auto rounded bg-red-100 px-2 py-1 text-sm text-red-700">
-            {tacticError || error}
-          </div>
+        {hasSession && (
+          <>
+            <div className="pe-sep" />
+            <div className="pe-session-chip">
+              <span className="chip-dot" />
+              <span className="chip-muted">proving</span>
+              <span className="chip-claim">{activeClaimName || '—'}</span>
+            </div>
+          </>
         )}
-      </header>
-      {/* Source code input panel (collapsible) */}
-      <SourceCodePanel />
-      {/* AI Settings panel (collapsible) */}
-      <AISettingsPanel />
-      <main className="flex flex-1 overflow-hidden">
-        {/* Tactic palette (left) */}
-        <TacticPalette />
-        {/* Main canvas area */}
-        <div className="flex-1">
-          <ProofCanvas />
+
+        <div className="pe-tb-right">
+          {displayError ? (
+            <span className="pe-error-pill">
+              <span style={{ width: 6, height: 6, borderRadius: 3, background: 'var(--pe-err)', flexShrink: 0 }} />
+              {displayError.length > 60 ? displayError.slice(0, 60) + '…' : displayError}
+            </span>
+          ) : (
+            <span className="pe-auto-indicator" title="Source and canvas stay in sync automatically">
+              <span className="pe-pulse" />
+              Auto-sync on
+            </span>
+          )}
         </div>
-        {/* Definitions panel (right sidebar) */}
-        <DefinitionsPanel
-          definitions={globalContext.definitions}
-          theorems={globalContext.theorems}
-          collapsed={definitionsPanelCollapsed}
-          onToggleCollapse={() => setDefinitionsPanelCollapsed(!definitionsPanelCollapsed)}
-        />
-        {/* Detail panel (rightmost) */}
-        <DetailPanel />
-      </main>
+      </header>
+
+      {/* ============ MAIN 4-COLUMN GRID ============ */}
+      <div className={`pe-main${sourceCollapsed ? ' source-collapsed' : ''}`}>
+
+        {/* Collapsed stub */}
+        <button
+          className="pe-source-stub"
+          onClick={handleExpandSource}
+          title="Expand source panel"
+          aria-label="Expand source panel"
+        >
+          <svg width="14" height="14" viewBox="0 0 14 14" fill="none" stroke="currentColor" strokeWidth="1.6" strokeLinecap="round">
+            <path d="M5 3l3 4-3 4" />
+          </svg>
+          <span className="pe-stub-label">Source</span>
+          <span className="pe-stub-sync">
+            <span style={{ display: 'block', width: 6, height: 6, borderRadius: 3, background: hasSession ? 'var(--pe-ok)' : 'var(--pe-faint)' }} />
+          </span>
+        </button>
+
+        {/* Source rail */}
+        <section className="pe-source">
+          <SourceCodePanel
+            onCollapse={handleCollapseSource}
+          />
+        </section>
+
+        {/* Tactic palette */}
+        <section className="pe-tactics">
+          <TacticPalette />
+        </section>
+
+        {/* Canvas */}
+        <section className="pe-canvas-wrap">
+          <div className="pe-canvas-head">
+            <div className="pe-breadcrumb">
+              <span>proof</span>
+              <svg width="10" height="10" viewBox="0 0 10 10" fill="none" stroke="#aaa" strokeWidth="1.6">
+                <path d="M3.5 2l3 3-3 3" />
+              </svg>
+              <span className="cur">{activeClaimName || '—'}</span>
+              {openGoals > 0 && (
+                <>
+                  <svg width="10" height="10" viewBox="0 0 10 10" fill="none" stroke="#aaa" strokeWidth="1.6">
+                    <path d="M3.5 2l3 3-3 3" />
+                  </svg>
+                  <span style={{ color: 'var(--pe-goal-current)' }}>{openGoals} open goal{openGoals !== 1 ? 's' : ''}</span>
+                </>
+              )}
+            </div>
+            <div style={{ flex: 1 }} />
+            <div className="pe-canvas-actions">
+              <button className="pe-icon-btn" title="Auto-layout" id="pe-canvas-autolayout">
+                <svg width="13" height="13" viewBox="0 0 13 13" fill="none" stroke="currentColor" strokeWidth="1.5">
+                  <rect x="1" y="1" width="4" height="4" /><rect x="8" y="1" width="4" height="4" />
+                  <rect x="4.5" y="8" width="4" height="4" />
+                  <path d="M3 5v1.5h6.5V5M6.5 6.5V8" />
+                </svg>
+              </button>
+              <button className="pe-icon-btn" title="Fit view" id="pe-canvas-fit">
+                <svg width="13" height="13" viewBox="0 0 13 13" fill="none" stroke="currentColor" strokeWidth="1.5" strokeLinecap="round">
+                  <path d="M1 4V1h3M12 4V1H9M1 9v3h3M12 9v3H9" />
+                </svg>
+              </button>
+              <button
+                className="pe-icon-btn"
+                title="AI Hints settings"
+                onClick={() => setAiPanelOpen((v) => !v)}
+                style={aiPanelOpen ? { background: 'var(--pe-accent-soft)', color: 'var(--pe-accent)', borderColor: 'color-mix(in oklab, var(--pe-accent) 30%, var(--pe-line))' } : undefined}
+              >
+                <svg width="13" height="13" viewBox="0 0 13 13" fill="none" stroke="currentColor" strokeWidth="1.5">
+                  <circle cx="6.5" cy="6.5" r="2" />
+                  <path strokeLinecap="round" d="M6.5 1v1.5M6.5 10v1.5M1 6.5h1.5M10 6.5h1.5M2.6 2.6l1 1M9.4 9.4l1 1M9.4 2.6l-1 1M3.6 9.4l-1 1" />
+                </svg>
+              </button>
+            </div>
+          </div>
+
+          {/* ReactFlow canvas — fills all remaining height */}
+          <div style={{ flex: 1, minHeight: 0 }}>
+            <ProofCanvas />
+          </div>
+
+          <div className="pe-canvas-status">
+            {hasSession ? (
+              <>
+                <span className="pe-cs-item">
+                  <span className="pe-cs-dot" />
+                  {nodes.length} nodes · {edges.length} edges
+                </span>
+                {openGoals > 0 && (
+                  <span className="pe-cs-item">{openGoals} open goal{openGoals !== 1 ? 's' : ''}</span>
+                )}
+                {appliedTactics > 0 && (
+                  <span className="pe-cs-item">{appliedTactics} applied tactic{appliedTactics !== 1 ? 's' : ''}</span>
+                )}
+              </>
+            ) : (
+              <span className="pe-cs-item" style={{ color: 'var(--pe-faint)' }}>No active session · select an example or start a proof</span>
+            )}
+          </div>
+        </section>
+
+        {/* Detail rail */}
+        <section className="pe-detail">
+          <DetailPanel
+            definitions={globalContext.definitions}
+            theorems={globalContext.theorems}
+          />
+        </section>
+
+      </div>
+      {/* AI Settings flyout */}
+      {aiPanelOpen && (
+        <>
+          <div
+            style={{ position: 'fixed', inset: 0, zIndex: 39 }}
+            onClick={() => setAiPanelOpen(false)}
+          />
+          <div className="pe-modal-overlay" style={{ pointerEvents: 'none' }}>
+            <div className="pe-modal-panel" style={{ pointerEvents: 'auto' }}>
+              <div className="pe-modal-head">
+                <h3>AI Hints</h3>
+                <button
+                  className="pe-icon-btn"
+                  onClick={() => setAiPanelOpen(false)}
+                  style={{ border: 'none', background: 'none' }}
+                >
+                  <svg width="12" height="12" viewBox="0 0 12 12" fill="none" stroke="currentColor" strokeWidth="1.6" strokeLinecap="round">
+                    <path d="M2 2l8 8M10 2L2 10" />
+                  </svg>
+                </button>
+              </div>
+              <div className="pe-modal-body">
+                <AISettingsPanel inModal />
+              </div>
+            </div>
+          </div>
+        </>
+      )}
+
     </div>
   );
 }

--- a/web-react/src/features/proof-editor/components/ProofCanvas.tsx
+++ b/web-react/src/features/proof-editor/components/ProofCanvas.tsx
@@ -2,8 +2,8 @@ import { useCallback, useRef, useMemo, useEffect, useState } from "react";
 import {
   ReactFlow,
   Background,
-  Controls,
   MiniMap,
+  Panel,
   useReactFlow,
   type NodeMouseHandler,
   type NodeChange,
@@ -41,7 +41,7 @@ export function ProofCanvas() {
   useDemoData();
 
   const reactFlowWrapper = useRef<HTMLDivElement>(null);
-  const { screenToFlowPosition } = useReactFlow();
+  const { screenToFlowPosition, zoomIn, zoomOut, fitView } = useReactFlow();
 
   // State for delete confirmation dialog
   const [deleteConfirmation, setDeleteConfirmation] = useState<{
@@ -521,6 +521,7 @@ export function ProofCanvas() {
         defaultEdgeOptions={{
           type: "smoothstep",
           animated: false,
+          pathOptions: { borderRadius: 12, offset: 24 },
         }}
         connectionLineStyle={{ stroke: "#94a3b8", strokeWidth: 2 }}
         proOptions={{
@@ -528,55 +529,67 @@ export function ProofCanvas() {
         }}
       >
         <Background color="#e5e7eb" gap={16} />
-        <Controls />
-        {/* Control buttons - Reset Layout and Expand All */}
-        {(hasManualPositions || hasCollapsedBranches) && (
-          <div className="absolute bottom-4 left-4 z-10 flex gap-2">
+
+        {/* Bottom-left: zoom controls + optional Reset/Expand */}
+        <Panel position="bottom-left">
+          <div style={{ display: 'flex', flexDirection: 'column', gap: 4 }}>
+            {/* Zoom toolbar */}
+            <div style={{ display: 'flex', flexDirection: 'column', background: '#fff', borderRadius: 6, boxShadow: '0 1px 4px rgba(0,0,0,0.12)', border: '1px solid #e5e7eb', overflow: 'hidden' }}>
+              <button
+                onClick={() => zoomIn({ duration: 200 })}
+                title="Zoom in"
+                style={{ padding: '6px 8px', border: 'none', background: 'none', cursor: 'pointer', color: '#374151', lineHeight: 1 }}
+                onMouseEnter={e => (e.currentTarget.style.background = '#f9fafb')}
+                onMouseLeave={e => (e.currentTarget.style.background = 'none')}
+              >
+                <svg width="13" height="13" viewBox="0 0 13 13" fill="none" stroke="currentColor" strokeWidth="1.6" strokeLinecap="round"><path d="M6.5 2v9M2 6.5h9" /></svg>
+              </button>
+              <div style={{ height: 1, background: '#e5e7eb' }} />
+              <button
+                onClick={() => zoomOut({ duration: 200 })}
+                title="Zoom out"
+                style={{ padding: '6px 8px', border: 'none', background: 'none', cursor: 'pointer', color: '#374151', lineHeight: 1 }}
+                onMouseEnter={e => (e.currentTarget.style.background = '#f9fafb')}
+                onMouseLeave={e => (e.currentTarget.style.background = 'none')}
+              >
+                <svg width="13" height="13" viewBox="0 0 13 13" fill="none" stroke="currentColor" strokeWidth="1.6" strokeLinecap="round"><path d="M2 6.5h9" /></svg>
+              </button>
+              <div style={{ height: 1, background: '#e5e7eb' }} />
+              <button
+                onClick={() => fitView({ padding: 0.2, duration: 300 })}
+                title="Fit view"
+                style={{ padding: '6px 8px', border: 'none', background: 'none', cursor: 'pointer', color: '#374151', lineHeight: 1 }}
+                onMouseEnter={e => (e.currentTarget.style.background = '#f9fafb')}
+                onMouseLeave={e => (e.currentTarget.style.background = 'none')}
+              >
+                <svg width="13" height="13" viewBox="0 0 13 13" fill="none" stroke="currentColor" strokeWidth="1.5" strokeLinecap="round"><path d="M1 4V1h3M12 4V1H9M1 9v3h3M12 9v3H9" /></svg>
+              </button>
+            </div>
+
+            {/* Reset Layout / Expand All — only when relevant */}
             {hasManualPositions && (
               <button
                 onClick={clearManualPositions}
-                className="flex items-center gap-1.5 rounded-md bg-white px-3 py-1.5 text-xs font-medium text-gray-700 shadow-md ring-1 ring-gray-200 hover:bg-gray-50"
-                title="Reset nodes to auto-layout positions"
+                title="Reset to auto-layout"
+                style={{ display: 'flex', alignItems: 'center', gap: 5, padding: '5px 8px', background: '#fff', border: '1px solid #e5e7eb', borderRadius: 6, boxShadow: '0 1px 4px rgba(0,0,0,0.12)', cursor: 'pointer', fontSize: 11, fontWeight: 500, color: '#374151' }}
               >
-                <svg
-                  xmlns="http://www.w3.org/2000/svg"
-                  viewBox="0 0 20 20"
-                  fill="currentColor"
-                  className="h-3.5 w-3.5"
-                >
-                  <path
-                    fillRule="evenodd"
-                    d="M15.312 11.424a5.5 5.5 0 01-9.201 2.466l-.312-.311h2.433a.75.75 0 000-1.5H3.989a.75.75 0 00-.75.75v4.242a.75.75 0 001.5 0v-2.43l.31.31a7 7 0 0011.712-3.138.75.75 0 00-1.449-.39zm1.23-3.723a.75.75 0 00.219-.53V2.929a.75.75 0 00-1.5 0V5.36l-.31-.31A7 7 0 003.239 8.188a.75.75 0 101.448.389A5.5 5.5 0 0113.89 6.11l.311.31h-2.432a.75.75 0 000 1.5h4.243a.75.75 0 00.53-.219z"
-                    clipRule="evenodd"
-                  />
-                </svg>
+                <svg width="12" height="12" viewBox="0 0 20 20" fill="currentColor"><path fillRule="evenodd" d="M15.312 11.424a5.5 5.5 0 01-9.201 2.466l-.312-.311h2.433a.75.75 0 000-1.5H3.989a.75.75 0 00-.75.75v4.242a.75.75 0 001.5 0v-2.43l.31.31a7 7 0 0011.712-3.138.75.75 0 00-1.449-.39zm1.23-3.723a.75.75 0 00.219-.53V2.929a.75.75 0 00-1.5 0V5.36l-.31-.31A7 7 0 003.239 8.188a.75.75 0 101.448.389A5.5 5.5 0 0113.89 6.11l.311.31h-2.432a.75.75 0 000 1.5h4.243a.75.75 0 00.53-.219z" clipRule="evenodd" /></svg>
                 Reset Layout
               </button>
             )}
             {hasCollapsedBranches && (
               <button
                 onClick={expandAllBranches}
-                className="flex items-center gap-1.5 rounded-md bg-white px-3 py-1.5 text-xs font-medium text-gray-700 shadow-md ring-1 ring-gray-200 hover:bg-gray-50"
-                title="Expand all collapsed branches"
+                title="Expand all branches"
+                style={{ display: 'flex', alignItems: 'center', gap: 5, padding: '5px 8px', background: '#fff', border: '1px solid #e5e7eb', borderRadius: 6, boxShadow: '0 1px 4px rgba(0,0,0,0.12)', cursor: 'pointer', fontSize: 11, fontWeight: 500, color: '#374151' }}
               >
-                <svg
-                  xmlns="http://www.w3.org/2000/svg"
-                  viewBox="0 0 20 20"
-                  fill="currentColor"
-                  className="h-3.5 w-3.5"
-                >
-                  <path
-                    fillRule="evenodd"
-                    d="M5.23 7.21a.75.75 0 011.06.02L10 11.168l3.71-3.938a.75.75 0 111.08 1.04l-4.25 4.5a.75.75 0 01-1.08 0l-4.25-4.5a.75.75 0 01.02-1.06z"
-                    clipRule="evenodd"
-                  />
-                </svg>
+                <svg width="12" height="12" viewBox="0 0 20 20" fill="currentColor"><path fillRule="evenodd" d="M5.23 7.21a.75.75 0 011.06.02L10 11.168l3.71-3.938a.75.75 0 111.08 1.04l-4.25 4.5a.75.75 0 01-1.08 0l-4.25-4.5a.75.75 0 01.02-1.06z" clipRule="evenodd" /></svg>
                 Expand All
               </button>
             )}
           </div>
-        )}
-        <MiniMap
+        </Panel>
+        {nodes.length > 8 && <MiniMap
           nodeStrokeColor={(node) => {
             if (node.type === "goal") {
               const data = node.data as { status?: string };
@@ -605,7 +618,7 @@ export function ProofCanvas() {
           }}
           maskColor="rgba(0, 0, 0, 0.1)"
           className="!bottom-24 !right-4"
-        />
+        />}
       </ReactFlow>
 
       {/* Delete confirmation dialog */}

--- a/web-react/src/features/proof-editor/components/panels/AISettingsPanel.tsx
+++ b/web-react/src/features/proof-editor/components/panels/AISettingsPanel.tsx
@@ -3,16 +3,111 @@ import { useHintStore } from '../../store';
 import { Sparkles, Eye, EyeOff, Check, AlertCircle } from 'lucide-react';
 import { cn } from '@/shared/lib/utils';
 
-/**
- * AISettingsPanel - Panel for configuring AI-powered hints
- *
- * Features:
- * - Input field for Gemini API key
- * - Toggle to show/hide key
- * - Status indicator for AI availability
- * - Link to get API key
- */
-export function AISettingsPanel() {
+interface ContentProps {
+  hasApiKey: boolean;
+  showKey: boolean;
+  inputValue: string;
+  setInputValue: (v: string) => void;
+  setShowKey: (v: boolean) => void;
+  handleSaveKey: () => void;
+  handleClearKey: () => void;
+}
+
+function AISettingsContent({
+  hasApiKey,
+  showKey,
+  inputValue,
+  setInputValue,
+  setShowKey,
+  handleSaveKey,
+  handleClearKey,
+}: ContentProps) {
+  return (
+    <div className="space-y-3">
+      <p className="text-sm text-muted-foreground">
+        Enter your Google Gemini API key to enable AI-powered hints.
+        The AI analyzes your proof goals and suggests appropriate tactics.
+      </p>
+
+      <div>
+        <label className="mb-1 block text-sm font-medium">Gemini API Key</label>
+        <div className="flex gap-2">
+          <div className="relative flex-1">
+            <input
+              type={showKey ? 'text' : 'password'}
+              className="w-full rounded-md border bg-background px-3 py-2 pr-10 font-mono text-sm focus:outline-none focus:ring-2 focus:ring-purple-500"
+              placeholder="AIza..."
+              value={inputValue}
+              onChange={(e) => setInputValue(e.target.value)}
+              onBlur={handleSaveKey}
+              onKeyDown={(e) => { if (e.key === 'Enter') handleSaveKey(); }}
+            />
+            <button
+              type="button"
+              className="absolute right-2 top-1/2 -translate-y-1/2 p-1 text-gray-400 hover:text-gray-600"
+              onClick={() => setShowKey(!showKey)}
+            >
+              {showKey ? <EyeOff className="h-4 w-4" /> : <Eye className="h-4 w-4" />}
+            </button>
+          </div>
+          {hasApiKey && (
+            <button
+              className="rounded-md bg-gray-200 px-3 py-2 text-sm hover:bg-gray-300"
+              onClick={handleClearKey}
+            >
+              Clear
+            </button>
+          )}
+        </div>
+      </div>
+
+      <div>
+        <a
+          href="https://aistudio.google.com/app/apikey"
+          target="_blank"
+          rel="noopener noreferrer"
+          className="text-sm text-purple-600 hover:text-purple-800 hover:underline"
+        >
+          Get a free Gemini API key →
+        </a>
+      </div>
+
+      {hasApiKey ? (
+        <div className="rounded-md border border-purple-200 bg-purple-50 p-3">
+          <div className="flex items-start gap-2">
+            <Sparkles className="mt-0.5 h-4 w-4 text-purple-500" />
+            <div>
+              <p className="text-sm font-medium text-purple-800">AI Hints Active</p>
+              <p className="text-xs text-purple-600">
+                Click the lightbulb on any goal to get AI-powered suggestions.
+              </p>
+            </div>
+          </div>
+        </div>
+      ) : (
+        <div className="rounded-md border border-amber-200 bg-amber-50 p-3">
+          <div className="flex items-start gap-2">
+            <AlertCircle className="mt-0.5 h-4 w-4 text-amber-500" />
+            <div>
+              <p className="text-sm font-medium text-amber-800">Using Rule-Based Hints</p>
+              <p className="text-xs text-amber-600">
+                Without an API key, hints use simple pattern matching.
+                Add a Gemini API key for smarter suggestions.
+              </p>
+            </div>
+          </div>
+        </div>
+      )}
+    </div>
+  );
+}
+
+interface AISettingsPanelProps {
+  /** When true, renders content directly without the collapsible wrapper */
+  inModal?: boolean;
+}
+
+export function AISettingsPanel({ inModal = false }: AISettingsPanelProps) {
   const apiKey = useHintStore((s) => s.apiKey);
   const setApiKey = useHintStore((s) => s.setApiKey);
 
@@ -21,8 +116,7 @@ export function AISettingsPanel() {
   const [inputValue, setInputValue] = useState(apiKey || '');
 
   const handleSaveKey = useCallback(() => {
-    const trimmedKey = inputValue.trim();
-    setApiKey(trimmedKey || null);
+    setApiKey(inputValue.trim() || null);
   }, [inputValue, setApiKey]);
 
   const handleClearKey = useCallback(() => {
@@ -31,10 +125,33 @@ export function AISettingsPanel() {
   }, [setApiKey]);
 
   const hasApiKey = !!apiKey;
+  const contentProps: ContentProps = {
+    hasApiKey, showKey, inputValue,
+    setInputValue, setShowKey, handleSaveKey, handleClearKey,
+  };
+
+  if (inModal) {
+    return (
+      <div>
+        <div className="flex items-center gap-2 mb-3">
+          <Sparkles className={cn('h-4 w-4', hasApiKey ? 'text-purple-500' : 'text-gray-400')} />
+          {hasApiKey ? (
+            <span className="flex items-center gap-1 rounded-full bg-purple-100 px-2 py-0.5 text-xs text-purple-700">
+              <Check className="h-3 w-3" /> Enabled
+            </span>
+          ) : (
+            <span className="flex items-center gap-1 rounded-full bg-gray-100 px-2 py-0.5 text-xs text-gray-600">
+              <AlertCircle className="h-3 w-3" /> Not configured
+            </span>
+          )}
+        </div>
+        <AISettingsContent {...contentProps} />
+      </div>
+    );
+  }
 
   return (
     <div className="border-b bg-card">
-      {/* Header - always visible */}
       <div
         className="flex cursor-pointer items-center justify-between px-4 py-2 hover:bg-muted/50"
         onClick={() => setIsExpanded(!isExpanded)}
@@ -44,112 +161,20 @@ export function AISettingsPanel() {
           <span className="font-medium">AI Hints</span>
           {hasApiKey ? (
             <span className="flex items-center gap-1 rounded-full bg-purple-100 px-2 py-0.5 text-xs text-purple-700">
-              <Check className="h-3 w-3" />
-              Enabled
+              <Check className="h-3 w-3" /> Enabled
             </span>
           ) : (
             <span className="flex items-center gap-1 rounded-full bg-gray-100 px-2 py-0.5 text-xs text-gray-600">
-              <AlertCircle className="h-3 w-3" />
-              Not configured
+              <AlertCircle className="h-3 w-3" /> Not configured
             </span>
           )}
         </div>
         <span className="text-lg">{isExpanded ? '▼' : '▶'}</span>
       </div>
 
-      {/* Collapsible content */}
       {isExpanded && (
         <div className="border-t px-4 pb-4 pt-3">
-          <div className="mb-3">
-            <p className="text-sm text-muted-foreground">
-              Enter your Google Gemini API key to enable AI-powered hints.
-              The AI analyzes your proof goals and suggests appropriate tactics.
-            </p>
-          </div>
-
-          {/* API Key input */}
-          <div className="mb-3">
-            <label className="mb-1 block text-sm font-medium">
-              Gemini API Key
-            </label>
-            <div className="flex gap-2">
-              <div className="relative flex-1">
-                <input
-                  type={showKey ? 'text' : 'password'}
-                  className="w-full rounded-md border bg-background px-3 py-2 pr-10 font-mono text-sm focus:outline-none focus:ring-2 focus:ring-purple-500"
-                  placeholder="AIza..."
-                  value={inputValue}
-                  onChange={(e) => setInputValue(e.target.value)}
-                  onBlur={handleSaveKey}
-                  onKeyDown={(e) => {
-                    if (e.key === 'Enter') handleSaveKey();
-                  }}
-                />
-                <button
-                  type="button"
-                  className="absolute right-2 top-1/2 -translate-y-1/2 p-1 text-gray-400 hover:text-gray-600"
-                  onClick={() => setShowKey(!showKey)}
-                >
-                  {showKey ? <EyeOff className="h-4 w-4" /> : <Eye className="h-4 w-4" />}
-                </button>
-              </div>
-              {hasApiKey && (
-                <button
-                  className="rounded-md bg-gray-200 px-3 py-2 text-sm hover:bg-gray-300"
-                  onClick={handleClearKey}
-                >
-                  Clear
-                </button>
-              )}
-            </div>
-          </div>
-
-          {/* Get API key link */}
-          <div className="mb-3">
-            <a
-              href="https://aistudio.google.com/app/apikey"
-              target="_blank"
-              rel="noopener noreferrer"
-              className="text-sm text-purple-600 hover:text-purple-800 hover:underline"
-            >
-              Get a free Gemini API key →
-            </a>
-          </div>
-
-          {/* Status */}
-          {hasApiKey && (
-            <div className="rounded-md border border-purple-200 bg-purple-50 p-3">
-              <div className="flex items-start gap-2">
-                <Sparkles className="mt-0.5 h-4 w-4 text-purple-500" />
-                <div>
-                  <p className="text-sm font-medium text-purple-800">
-                    AI Hints Active
-                  </p>
-                  <p className="text-xs text-purple-600">
-                    Click the lightbulb on any goal to get AI-powered suggestions.
-                    The AI uses Gemini to analyze your proof and suggest tactics.
-                  </p>
-                </div>
-              </div>
-            </div>
-          )}
-
-          {!hasApiKey && (
-            <div className="rounded-md border border-amber-200 bg-amber-50 p-3">
-              <div className="flex items-start gap-2">
-                <AlertCircle className="mt-0.5 h-4 w-4 text-amber-500" />
-                <div>
-                  <p className="text-sm font-medium text-amber-800">
-                    Using Rule-Based Hints
-                  </p>
-                  <p className="text-xs text-amber-600">
-                    Without an API key, hints use simple pattern matching.
-                    Add a Gemini API key for smarter, context-aware suggestions.
-                  </p>
-                </div>
-              </div>
-            </div>
-          )}
+          <AISettingsContent {...contentProps} />
         </div>
       )}
     </div>

--- a/web-react/src/features/proof-editor/components/panels/DetailPanel.tsx
+++ b/web-react/src/features/proof-editor/components/panels/DetailPanel.tsx
@@ -1,47 +1,254 @@
+import { useState } from 'react';
 import { useProofStore, useUIStore } from '../../store';
-import { GoalDetailPanel } from './GoalDetailPanel';
-import { TacticDetailPanel } from './TacticDetailPanel';
+import type { GoalNode } from '../../store/types';
+import { TACTICS } from '../../data/tactics';
+import type { GlobalEntry } from '@pie/protocol';
 
-/**
- * DetailPanel Component
- *
- * Unified side panel that shows details for the selected node.
- * Switches between GoalDetailPanel and TacticDetailPanel based on node type.
- */
-export function DetailPanel() {
+interface DetailPanelProps {
+  definitions?: GlobalEntry[];
+  theorems?: GlobalEntry[];
+}
+
+type Tab = 'details' | 'context' | 'history';
+
+// Suggested tactics based on goal type heuristics
+function getSuggestedTactics(goalType: string): string[] {
+  const suggestions: string[] = [];
+  if (goalType.includes('Pi') || goalType.includes('->')) suggestions.push('intro');
+  if (goalType.includes('Sigma') || goalType.includes('Pair')) suggestions.push('split', 'exists');
+  if (goalType.includes('Either')) suggestions.push('left', 'right');
+  if (goalType.includes('= Nat') || goalType.includes('Nat')) suggestions.push('elimNat', 'exact');
+  if (goalType.includes('= ')) suggestions.push('symm', 'cong');
+  suggestions.push('exact');
+  return [...new Set(suggestions)].slice(0, 5);
+}
+
+export function DetailPanel({ definitions = [], theorems = [] }: DetailPanelProps) {
+  const [activeTab, setActiveTab] = useState<Tab>('details');
+  const [selectedDef, setSelectedDef] = useState<string | null>(null);
+
   const selectedNodeId = useUIStore((s) => s.selectedNodeId);
+  const selectNode = useUIStore((s) => s.selectNode);
   const nodes = useProofStore((s) => s.nodes);
 
-  // Find the selected node to determine which panel to show
   const selectedNode = nodes.find((n) => n.id === selectedNodeId);
+  const goalNode = selectedNode?.type === 'goal'
+    ? (selectedNode as GoalNode)
+    : null;
 
-  // No selection - show placeholder
-  if (!selectedNode) {
-    return (
-      <div className="w-80 border-l bg-gray-50 p-4">
-        <p className="text-sm text-gray-500">
-          Click on a node to see details
-        </p>
+  const suggestions = goalNode
+    ? getSuggestedTactics(goalNode.data.goalType)
+    : [];
+
+  const hasContent = selectedNode || definitions.length > 0 || theorems.length > 0;
+
+  return (
+    <>
+      {/* Tabs */}
+      <div className="pe-detail-tabs">
+        {(['details', 'context', 'history'] as Tab[]).map((tab) => (
+          <button
+            key={tab}
+            className={`pe-detail-tab${activeTab === tab ? ' active' : ''}`}
+            onClick={() => setActiveTab(tab)}
+          >
+            {tab.charAt(0).toUpperCase() + tab.slice(1)}
+          </button>
+        ))}
       </div>
-    );
-  }
 
-  // Show appropriate panel based on node type
-  switch (selectedNode.type) {
-    case 'goal':
-      return <GoalDetailPanel />;
-    case 'tactic':
-      return <TacticDetailPanel />;
-    case 'lemma':
-      // TODO: LemmaDetailPanel
-      return (
-        <div className="w-80 border-l bg-gray-50 p-4">
-          <p className="text-sm text-gray-500">
-            Lemma details coming soon
-          </p>
-        </div>
-      );
-    default:
-      return null;
-  }
+      <div className="pe-detail-body">
+
+        {/* ── DETAILS TAB ── */}
+        {activeTab === 'details' && (
+          <>
+            {/* Selected node info */}
+            {selectedNode ? (
+              <div className="pe-d-section" style={{ paddingBottom: 10 }}>
+                <div className="pe-d-section-hd">
+                  <span className="pe-d-section-label">
+                    {selectedNode.type === 'goal'
+                      ? `Goal${goalNode?.data.status ? ` · ${goalNode.data.status}` : ''}`
+                      : selectedNode.type === 'tactic'
+                        ? 'Tactic'
+                        : selectedNode.type}
+                  </span>
+                  <button
+                    onClick={() => selectNode(null)}
+                    style={{ border: 'none', background: 'none', cursor: 'pointer', color: 'var(--pe-faint)', padding: 2, borderRadius: 3 }}
+                    title="Deselect"
+                  >
+                    <svg width="10" height="10" viewBox="0 0 10 10" fill="none" stroke="currentColor" strokeWidth="1.6" strokeLinecap="round">
+                      <path d="M2 2l6 6M8 2L2 8" />
+                    </svg>
+                  </button>
+                </div>
+
+                {goalNode && (
+                  <>
+                    <div className="pe-big-type">{goalNode.data.goalType}</div>
+                    <div className="pe-meta">
+                      <span><b>ctx</b> {goalNode.data.context.length} var{goalNode.data.context.length !== 1 ? 's' : ''}</span>
+                      {goalNode.data.parentGoalId && (
+                        <span
+                          style={{ cursor: 'pointer', color: 'var(--pe-accent)' }}
+                          onClick={() => goalNode.data.parentGoalId && selectNode(goalNode.data.parentGoalId)}
+                        >
+                          ↑ parent
+                        </span>
+                      )}
+                    </div>
+                  </>
+                )}
+
+                {selectedNode.type === 'tactic' && (
+                  <div style={{ fontFamily: 'var(--pe-mono-font)', fontSize: 13, fontWeight: 600, color: 'var(--pe-ink)', marginTop: 4 }}>
+                    {(selectedNode.data as { displayName?: string }).displayName ?? 'tactic'}
+                  </div>
+                )}
+              </div>
+            ) : !hasContent && (
+              <div className="pe-d-section" style={{ color: 'var(--pe-faint)', fontSize: 12 }}>
+                Click a node to see details
+              </div>
+            )}
+
+            {/* Suggested tactics (only when goal selected) */}
+            {goalNode && suggestions.length > 0 && (
+              <div className="pe-d-section">
+                <div className="pe-d-section-hd">
+                  <span className="pe-d-section-label">Suggested tactics</span>
+                </div>
+                <div className="pe-suggested">
+                  {suggestions.map((name) => (
+                    <span key={name} className="pe-chip" title={TACTICS.find(t => t.type === name)?.description}>
+                      {name}
+                    </span>
+                  ))}
+                </div>
+              </div>
+            )}
+
+            {/* Definitions */}
+            {definitions.length > 0 && (
+              <div className="pe-d-section">
+                <div className="pe-d-section-hd">
+                  <span className="pe-d-section-label">Definitions</span>
+                  <span className="pe-d-section-count">{definitions.length}</span>
+                </div>
+                {definitions.map((def) => (
+                  <ContextItem
+                    key={def.name}
+                    entry={def}
+                    kind="def"
+                    isSelected={selectedDef === def.name}
+                    onClick={() => setSelectedDef(selectedDef === def.name ? null : def.name)}
+                  />
+                ))}
+              </div>
+            )}
+
+            {/* Theorems & claims */}
+            {theorems.length > 0 && (
+              <div className="pe-d-section">
+                <div className="pe-d-section-hd">
+                  <span className="pe-d-section-label">Theorems &amp; claims</span>
+                  <span className="pe-d-section-count">{theorems.length}</span>
+                </div>
+                {theorems.map((thm) => (
+                  <ContextItem
+                    key={thm.name}
+                    entry={thm}
+                    kind={thm.kind === 'claim' ? 'claim' : 'thm'}
+                    isSelected={selectedDef === thm.name}
+                    onClick={() => setSelectedDef(selectedDef === thm.name ? null : thm.name)}
+                  />
+                ))}
+              </div>
+            )}
+
+            {!selectedNode && definitions.length === 0 && theorems.length === 0 && (
+              <div className="pe-d-section" style={{ color: 'var(--pe-faint)', fontSize: 12 }}>
+                No definitions yet · start a proof session to see context
+              </div>
+            )}
+          </>
+        )}
+
+        {/* ── CONTEXT TAB ── */}
+        {activeTab === 'context' && (
+          <>
+            {goalNode ? (
+              <div className="pe-d-section">
+                <div className="pe-d-section-hd">
+                  <span className="pe-d-section-label">Local context</span>
+                  <span className="pe-d-section-count">{goalNode.data.context.length}</span>
+                </div>
+                {goalNode.data.context.length === 0 ? (
+                  <div style={{ color: 'var(--pe-faint)', fontSize: 12, fontStyle: 'italic' }}>No bindings in scope</div>
+                ) : (
+                  goalNode.data.context.map((entry) => (
+                    <div key={entry.id} className="pe-ctx-row">
+                      <span>
+                        <span className="pe-ctx-var">{entry.name}</span>
+                        <span className="pe-ctx-type"> : {entry.type}</span>
+                      </span>
+                      {entry.origin === 'introduced' && (
+                        <span style={{
+                          fontSize: 9.5,
+                          padding: '1px 5px',
+                          borderRadius: 99,
+                          background: 'color-mix(in oklab, var(--pe-accent) 10%, white)',
+                          color: 'var(--pe-accent)',
+                          border: '1px solid color-mix(in oklab, var(--pe-accent) 22%, white)',
+                          fontFamily: 'var(--pe-mono-font)',
+                        }}>
+                          intro
+                        </span>
+                      )}
+                    </div>
+                  ))
+                )}
+              </div>
+            ) : (
+              <div className="pe-d-section" style={{ color: 'var(--pe-faint)', fontSize: 12 }}>
+                Select a goal node to see its local context
+              </div>
+            )}
+          </>
+        )}
+
+        {/* ── HISTORY TAB ── */}
+        {activeTab === 'history' && (
+          <div className="pe-d-section" style={{ color: 'var(--pe-faint)', fontSize: 12 }}>
+            Proof history coming soon
+          </div>
+        )}
+
+      </div>
+    </>
+  );
+}
+
+function ContextItem({
+  entry,
+  kind,
+  isSelected,
+  onClick,
+}: {
+  entry: GlobalEntry;
+  kind: 'def' | 'thm' | 'claim';
+  isSelected: boolean;
+  onClick: () => void;
+}) {
+  return (
+    <div
+      className={`pe-d-row${isSelected ? ' active' : ''}`}
+      onClick={onClick}
+    >
+      <span className={`pe-kindtag ${kind}`}>{kind}</span>
+      <span className="pe-d-name">{entry.name}</span>
+      <span className="pe-d-type" title={entry.type}>{entry.type}</span>
+    </div>
+  );
 }

--- a/web-react/src/features/proof-editor/components/panels/SourceCodePanel.tsx
+++ b/web-react/src/features/proof-editor/components/panels/SourceCodePanel.tsx
@@ -155,7 +155,7 @@ export function SourceCodePanel({ onCollapse }: SourceCodePanelProps) {
             onClick={onCollapse}
             title="Collapse source panel"
             aria-label="Collapse source panel"
-            style={{ marginRight: -4, marginLeft: -4 }}
+            style={{ marginLeft: -4, marginRight: 0, flexShrink: 0 }}
           >
             <svg width="12" height="12" viewBox="0 0 14 14" fill="none" stroke="currentColor" strokeWidth="1.6" strokeLinecap="round">
               <path d="M9 3L6 7l3 4" />
@@ -168,9 +168,6 @@ export function SourceCodePanel({ onCollapse }: SourceCodePanelProps) {
           {syncLabel}
         </span>
         <div style={{ flex: 1 }} />
-        <span style={{ fontFamily: 'var(--pe-mono-font)', fontSize: 11, color: 'var(--pe-faint)' }}>
-          Pie · UTF-8
-        </span>
       </div>
 
       {/* Claim bar */}
@@ -201,7 +198,6 @@ export function SourceCodePanel({ onCollapse }: SourceCodePanelProps) {
 
       {/* Monaco editor — fills remaining height */}
       <div className="pe-editor-frame">
-        <span className="pe-gutter-info">Pie · UTF-8 · LF</span>
         <Editor
           height="100%"
           language="pie"

--- a/web-react/src/features/proof-editor/components/panels/SourceCodePanel.tsx
+++ b/web-react/src/features/proof-editor/components/panels/SourceCodePanel.tsx
@@ -1,11 +1,9 @@
-import { useState, useCallback, useEffect } from 'react';
+import { useState, useCallback, useEffect, useRef } from 'react';
+import Editor, { type OnMount, type BeforeMount, type Monaco } from '@monaco-editor/react';
 import { useProofSession } from '../../hooks/useProofSession';
 import { useGeneratedProofScript } from '../../store';
 import { useExampleStore } from '../../store/example-store';
 
-/**
- * Sample Pie source code for demonstration.
- */
 const SAMPLE_SOURCE = `; Define addition function
 (claim + (-> Nat Nat Nat))
 (define +
@@ -21,38 +19,81 @@ const SAMPLE_SOURCE = `; Define addition function
     (= Nat n n)))
 `;
 
-/**
- * SourceCodePanel - Collapsible panel for entering Pie source code and starting proofs.
- *
- * Features:
- * - Text area for Pie source code (claims, definitions)
- * - Input field for claim name to prove
- * - "Start Proof" button
- * - Auto-collapses after starting proof
- * - Shows loading and error states
- * - Displays generated proof script
- */
-export function SourceCodePanel() {
-  const [isExpanded, setIsExpanded] = useState(true);
+const PIE_GUARD = '__pieLanguageRegistered' as const;
+
+function registerPieLanguage(monaco: Monaco) {
+  const langs = monaco.languages.getLanguages();
+  if (langs.find((l: { id: string }) => l.id === 'pie')) return;
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  if ((monaco as any)[PIE_GUARD]) return;
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  (monaco as any)[PIE_GUARD] = true;
+
+  monaco.languages.register({ id: 'pie' });
+
+  monaco.languages.setMonarchTokensProvider('pie', {
+    tokenizer: {
+      root: [
+        [/;.*$/, 'comment'],
+        [/"([^"\\]|\\.)*$/, 'string.invalid'],
+        [/"/, 'string', '@string'],
+        [/\d+/, 'number'],
+        [
+          /\b(claim|define|define-tactically|lambda|Pi|Sigma|the|rec-Nat|ind-Nat|ind-List|ind-Vec|ind-Either|ind-Absurd|replace|symm|cong|trans|data)\b/,
+          'keyword',
+        ],
+        [/\b(Nat|Atom|Trivial|Absurd|U|Pair|Either|List|Vec|->)\b/, 'type'],
+        [/\b(zero|add1|same|sole|nil|vecnil|cons|car|cdr|left|right)\b/, 'variable'],
+        [
+          /\b(intro|exact|split|exists|go-Left|go-Right|elim-Nat|elim-List|elim-Vec|elim-Either|elim-Equal|elim-Absurd|apply|then)\b/,
+          'string',
+        ],
+        [/[()[\]]/, 'delimiter'],
+        [/[a-zA-Z_][a-zA-Z0-9_\-?!*+/<>=]*/, 'identifier'],
+      ],
+      string: [
+        [/[^\\"]+/, 'string'],
+        [/\\./, 'string.escape'],
+        [/"/, 'string', '@pop'],
+      ],
+    },
+  });
+
+  monaco.editor.defineTheme('pie-dark', {
+    base: 'vs-dark',
+    inherit: true,
+    rules: [
+      { token: 'keyword', foreground: 'C586C0', fontStyle: 'bold' },
+      { token: 'type', foreground: '4EC9B0' },
+      { token: 'variable', foreground: '9CDCFE' },
+      { token: 'string', foreground: 'CE9178' },
+      { token: 'number', foreground: 'B5CEA8' },
+      { token: 'comment', foreground: '6A9955', fontStyle: 'italic' },
+      { token: 'identifier', foreground: 'D4D4D4' },
+      { token: 'delimiter', foreground: 'FFD700' },
+    ],
+    colors: {},
+  });
+}
+
+interface SourceCodePanelProps {
+  onCollapse?: () => void;
+}
+
+export function SourceCodePanel({ onCollapse }: SourceCodePanelProps) {
   const [sourceCode, setSourceCode] = useState(SAMPLE_SOURCE);
   const [claimName, setClaimName] = useState('reflexivity');
+  const editorRef = useRef<Parameters<OnMount>[0] | null>(null);
 
-  // Get example from store
   const exampleSource = useExampleStore((s) => s.exampleSource);
   const exampleClaim = useExampleStore((s) => s.exampleClaim);
 
-  // Update source/claim when example is selected
   useEffect(() => {
-    if (exampleSource !== undefined) {
-      setSourceCode(exampleSource);
-      setIsExpanded(true); // Expand to show the loaded example
-    }
+    if (exampleSource !== undefined) setSourceCode(exampleSource);
   }, [exampleSource]);
 
   useEffect(() => {
-    if (exampleClaim !== undefined) {
-      setClaimName(exampleClaim);
-    }
+    if (exampleClaim !== undefined) setClaimName(exampleClaim);
   }, [exampleClaim]);
 
   const {
@@ -64,161 +105,206 @@ export function SourceCodePanel() {
     claimType,
   } = useProofSession();
 
-  // Get the generated proof script from the store
   const generatedScript = useGeneratedProofScript();
 
   const handleStartProof = useCallback(async () => {
-    if (!sourceCode.trim() || !claimName.trim()) {
-      return;
-    }
-
+    if (!sourceCode.trim() || !claimName.trim()) return;
+    clearError();
     try {
       await startSession(sourceCode, claimName);
-      // Auto-collapse on success
-      setIsExpanded(false);
+      onCollapse?.();
     } catch (e) {
-      // Error is already set in the hook
       console.error('Failed to start proof:', e);
     }
-  }, [sourceCode, claimName, startSession]);
+  }, [sourceCode, claimName, startSession, clearError, onCollapse]);
 
-  const handleToggle = useCallback(() => {
-    setIsExpanded((prev) => !prev);
+  const handleBeforeMount: BeforeMount = useCallback((monaco) => {
+    registerPieLanguage(monaco);
   }, []);
 
+  const handleMount: OnMount = useCallback((editor, monaco) => {
+    editorRef.current = editor;
+    monaco.editor.setTheme('pie-dark');
+  }, []);
+
+  // Sync generated script back to editor when canvas changes
+  useEffect(() => {
+    if (!generatedScript || !editorRef.current) return;
+    const currentVal = editorRef.current.getValue();
+    if (!currentVal.includes('define-tactically') && generatedScript.includes('define-tactically')) return;
+    // Don't auto-update if user is actively editing
+  }, [generatedScript]);
+
+  const syncBadgeClass = isLoading
+    ? 'pe-sync-badge syncing'
+    : hasActiveSession
+      ? 'pe-sync-badge'
+      : error
+        ? 'pe-sync-badge error'
+        : 'pe-sync-badge';
+
+  const syncLabel = isLoading ? 'Syncing…' : hasActiveSession ? 'Active' : error ? 'Error' : 'Ready';
+
   return (
-    <div className="border-b bg-card">
-      {/* Header - always visible */}
-      <div
-        className="flex cursor-pointer items-center justify-between px-4 py-2 hover:bg-muted/50"
-        onClick={handleToggle}
-      >
-        <div className="flex items-center gap-2">
-          <span className="text-lg">{isExpanded ? '▼' : '▶'}</span>
-          <span className="font-medium">Source Code</span>
-          {hasActiveSession && claimType && (
-            <span className="ml-2 rounded bg-green-100 px-2 py-0.5 text-xs text-green-800">
-              Proving: {claimName}
+    <>
+      {/* Panel head */}
+      <div className="pe-panel-head">
+        {onCollapse && (
+          <button
+            className="pe-icon-btn"
+            onClick={onCollapse}
+            title="Collapse source panel"
+            aria-label="Collapse source panel"
+            style={{ marginRight: -4, marginLeft: -4 }}
+          >
+            <svg width="12" height="12" viewBox="0 0 14 14" fill="none" stroke="currentColor" strokeWidth="1.6" strokeLinecap="round">
+              <path d="M9 3L6 7l3 4" />
+            </svg>
+          </button>
+        )}
+        <h3>Source</h3>
+        <span className={syncBadgeClass}>
+          <span className="dot" />
+          {syncLabel}
+        </span>
+        <div style={{ flex: 1 }} />
+        <span style={{ fontFamily: 'var(--pe-mono-font)', fontSize: 11, color: 'var(--pe-faint)' }}>
+          Pie · UTF-8
+        </span>
+      </div>
+
+      {/* Claim bar */}
+      <div className="pe-source-claim">
+        <label>Claim</label>
+        <input
+          className="pe-input"
+          value={claimName}
+          onChange={(e) => setClaimName(e.target.value)}
+          onKeyDown={(e) => e.key === 'Enter' && handleStartProof()}
+          placeholder="e.g., +zero-identity"
+          disabled={isLoading}
+        />
+        <button
+          className="pe-btn"
+          onClick={handleStartProof}
+          disabled={isLoading || !sourceCode.trim() || !claimName.trim()}
+          title={hasActiveSession ? 'Restart proof session' : 'Start proof session'}
+        >
+          {isLoading ? (
+            <span style={{ display: 'inline-flex', alignItems: 'center', gap: 5 }}>
+              <span style={{ width: 10, height: 10, border: '2px solid currentColor', borderTopColor: 'transparent', borderRadius: '50%', animation: 'spin 0.8s linear infinite' }} />
+              Starting…
             </span>
-          )}
-        </div>
-        {hasActiveSession && (
-          <span className="text-sm text-muted-foreground">
-            Click to {isExpanded ? 'collapse' : 'expand'}
-          </span>
+          ) : hasActiveSession ? 'Restart' : 'Start Proof'}
+        </button>
+      </div>
+
+      {/* Monaco editor — fills remaining height */}
+      <div className="pe-editor-frame">
+        <span className="pe-gutter-info">Pie · UTF-8 · LF</span>
+        <Editor
+          height="100%"
+          language="pie"
+          value={sourceCode}
+          onChange={(v) => { if (v !== undefined) setSourceCode(v); }}
+          beforeMount={handleBeforeMount}
+          onMount={handleMount}
+          options={{
+            minimap: { enabled: false },
+            fontSize: 12.5,
+            fontFamily: "'JetBrains Mono', ui-monospace, monospace",
+            lineNumbers: 'on',
+            scrollBeyondLastLine: false,
+            wordWrap: 'on',
+            automaticLayout: true,
+            tabSize: 2,
+            insertSpaces: true,
+            readOnly: isLoading,
+            padding: { top: 12 },
+            scrollbar: { verticalScrollbarSize: 6, horizontalScrollbarSize: 6 },
+            overviewRulerLanes: 0,
+            folding: false,
+            lineDecorationsWidth: 0,
+          }}
+        />
+      </div>
+
+      {/* Diagnostics / status strip */}
+      <div className="pe-diag-strip">
+        {error ? (
+          <>
+            <div className="pe-diag-head">
+              <div className="title">
+                <span style={{ color: 'var(--pe-err)' }}>Error</span>
+              </div>
+              <button
+                style={{ fontSize: 10.5, color: 'var(--pe-err)', cursor: 'pointer', border: 'none', background: 'none', padding: '2px 4px' }}
+                onClick={clearError}
+              >
+                Dismiss
+              </button>
+            </div>
+            <ul className="pe-diag-list">
+              <li className="pe-diag-row err">
+                <span className="sev" />
+                <span className="loc">proof</span>
+                <span className="msg">{error}</span>
+              </li>
+            </ul>
+          </>
+        ) : hasActiveSession ? (
+          <>
+            <div className="pe-diag-head">
+              <div className="title">
+                <span style={{ color: 'var(--pe-ok)' }}>Active</span>
+                <span>·</span>
+                <span>{claimName}</span>
+              </div>
+            </div>
+            <div className="pe-diag-ok">
+              <span className="dot" />
+              {claimType
+                ? <>Session active · <span style={{ fontFamily: 'var(--pe-mono-font)', fontSize: 11 }}>{claimType.length > 50 ? claimType.slice(0, 50) + '…' : claimType}</span></>
+                : 'Proof session active · canvas is live'
+              }
+            </div>
+          </>
+        ) : (
+          <div className="pe-diag-ok" style={{ color: 'var(--pe-faint)' }}>
+            <span style={{ width: 6, height: 6, borderRadius: 3, background: 'var(--pe-faint)', flexShrink: 0 }} />
+            No active session · enter source code and start proof
+          </div>
         )}
       </div>
 
-      {/* Collapsible content */}
-      {isExpanded && (
-        <div className="border-t px-4 pb-4 pt-2">
-          <div className="grid grid-cols-1 gap-4 lg:grid-cols-3">
-            {/* Source code text area */}
-            <div className="lg:col-span-2">
-              <label className="mb-1 block text-sm font-medium text-muted-foreground">
-                Pie Source Code
-              </label>
-              <textarea
-                className="h-32 w-full rounded-md border bg-background px-3 py-2 font-mono text-sm focus:outline-none focus:ring-2 focus:ring-primary"
-                placeholder="Enter Pie source code (claims, definitions)..."
-                value={sourceCode}
-                onChange={(e) => setSourceCode(e.target.value)}
-                disabled={isLoading}
-              />
-            </div>
-
-            {/* Claim name and button */}
-            <div className="flex flex-col gap-3">
-              <div>
-                <label className="mb-1 block text-sm font-medium text-muted-foreground">
-                  Claim to Prove
-                </label>
-                <input
-                  type="text"
-                  className="w-full rounded-md border bg-background px-3 py-2 text-sm focus:outline-none focus:ring-2 focus:ring-primary"
-                  placeholder="e.g., +zero-identity"
-                  value={claimName}
-                  onChange={(e) => setClaimName(e.target.value)}
-                  disabled={isLoading}
-                />
-              </div>
-
-              <button
-                className="rounded-md bg-primary px-4 py-2 text-sm font-medium text-primary-foreground hover:bg-primary/90 disabled:cursor-not-allowed disabled:opacity-50"
-                onClick={handleStartProof}
-                disabled={isLoading || !sourceCode.trim() || !claimName.trim()}
-              >
-                {isLoading ? (
-                  <span className="flex items-center justify-center gap-2">
-                    <span className="h-4 w-4 animate-spin rounded-full border-2 border-current border-t-transparent" />
-                    Starting...
-                  </span>
-                ) : hasActiveSession ? (
-                  'Restart Proof'
-                ) : (
-                  'Start Proof'
-                )}
-              </button>
-
-              {/* Error display */}
-              {error && (
-                <div className="rounded-md border border-destructive/50 bg-destructive/10 p-2">
-                  <div className="flex items-start justify-between gap-2">
-                    <p className="text-xs text-destructive">{error}</p>
-                    <button
-                      className="text-xs text-destructive hover:underline"
-                      onClick={(e) => {
-                        e.stopPropagation();
-                        clearError();
-                      }}
-                    >
-                      Dismiss
-                    </button>
-                  </div>
-                </div>
-              )}
-
-              {/* Success indicator */}
-              {hasActiveSession && !error && (
-                <div className="rounded-md border border-green-200 bg-green-50 p-2">
-                  <p className="text-xs text-green-800">
-                    ✓ Proof session active
-                  </p>
-                  {claimType && (
-                    <p className="mt-1 truncate font-mono text-xs text-green-700">
-                      Type: {claimType}
-                    </p>
-                  )}
-                </div>
-              )}
-            </div>
+      {/* Generated script (collapsible) */}
+      {hasActiveSession && generatedScript && (
+        <div style={{
+          borderTop: '1px solid var(--pe-line-2)',
+          background: 'var(--pe-surface-2)',
+          flexShrink: 0,
+          maxHeight: 120,
+          overflow: 'auto',
+          padding: '8px 14px',
+        }}>
+          <div style={{ display: 'flex', alignItems: 'center', justifyContent: 'space-between', marginBottom: 6 }}>
+            <span style={{ fontSize: 10.5, letterSpacing: '0.08em', textTransform: 'uppercase', color: 'var(--pe-faint)', fontWeight: 600 }}>
+              Generated script
+            </span>
+            <button
+              className="pe-btn"
+              style={{ fontSize: 10.5, padding: '1px 7px' }}
+              onClick={() => navigator.clipboard.writeText(generatedScript)}
+              title="Copy to clipboard"
+            >
+              Copy
+            </button>
           </div>
-
-          {/* Generated proof script - shown when proof is active */}
-          {hasActiveSession && generatedScript && (
-            <div className="mt-4 border-t pt-4">
-              <div className="mb-2 flex items-center justify-between">
-                <label className="text-sm font-medium text-muted-foreground">
-                  Generated Proof Script
-                </label>
-                <button
-                  className="rounded bg-secondary px-2 py-1 text-xs hover:bg-secondary/80"
-                  onClick={(e) => {
-                    e.stopPropagation();
-                    navigator.clipboard.writeText(generatedScript);
-                  }}
-                  title="Copy to clipboard"
-                >
-                  Copy
-                </button>
-              </div>
-              <pre className="max-h-48 overflow-auto rounded-md border bg-muted/50 p-3 font-mono text-sm">
-                {generatedScript}
-              </pre>
-            </div>
-          )}
+          <pre style={{ margin: 0, fontFamily: 'var(--pe-mono-font)', fontSize: 11, color: 'var(--pe-ink-2)', whiteSpace: 'pre-wrap', wordBreak: 'break-all' }}>
+            {generatedScript}
+          </pre>
         </div>
       )}
-    </div>
+    </>
   );
 }

--- a/web-react/src/features/proof-editor/components/panels/TacticPalette.tsx
+++ b/web-react/src/features/proof-editor/components/panels/TacticPalette.tsx
@@ -1,5 +1,3 @@
-import { useState } from 'react';
-import { cn } from '@/shared/lib/utils';
 import { useUIStore } from '../../store';
 import {
   getTacticsByCategory,
@@ -8,117 +6,72 @@ import {
   type TacticCategory,
 } from '../../data/tactics';
 
-/**
- * TacticPalette Component
- *
- * A collapsible side panel displaying available tactics organized by category.
- * Tactics can be dragged onto the canvas to create new tactic nodes.
- */
+// Single-char glyph for each tactic (or first letter fallback)
+const TACTIC_GLYPH: Partial<Record<string, string>> = {
+  intro: 'i',
+  exact: 'e',
+  exists: '∃',
+  split: 's',
+  left: 'l',
+  right: 'r',
+  elimNat: 'N',
+  elimList: 'L',
+  elimVec: 'V',
+  elimEither: 'E',
+  elimEqual: '=',
+  elimAbsurd: '⊥',
+  apply: 'a',
+  then: '↪',
+  'go-Left': '←',
+  'go-Right': '→',
+};
+
+function getGlyph(tactic: TacticInfo): string {
+  return TACTIC_GLYPH[tactic.type] ?? tactic.displayName.charAt(0).toUpperCase();
+}
+
+function getTag(tactic: TacticInfo): string {
+  if (tactic.requiresContextVar) return 'ctx';
+  return '—';
+}
+
 export function TacticPalette() {
-  const [expandedCategories, setExpandedCategories] = useState<Set<TacticCategory>>(
-    new Set(['introduction', 'elimination'])
-  );
   const tacticsByCategory = getTacticsByCategory();
 
-  const toggleCategory = (category: TacticCategory) => {
-    setExpandedCategories((prev) => {
-      const next = new Set(prev);
-      if (next.has(category)) {
-        next.delete(category);
-      } else {
-        next.add(category);
-      }
-      return next;
-    });
-  };
-
   return (
-    <div className="w-56 border-r bg-gray-50 overflow-y-auto">
-      {/* Header */}
-      <div className="border-b bg-white p-3">
-        <h2 className="font-semibold text-sm">Tactics</h2>
-        <p className="text-xs text-gray-500 mt-1">Drag onto a goal</p>
-      </div>
-
-      {/* Categories */}
-      <div className="p-2 space-y-1">
-        {(Object.keys(tacticsByCategory) as TacticCategory[]).map((category) => (
-          <CategorySection
-            key={category}
-            category={category}
-            tactics={tacticsByCategory[category]}
-            isExpanded={expandedCategories.has(category)}
-            onToggle={() => toggleCategory(category)}
-          />
-        ))}
-      </div>
-    </div>
-  );
-}
-
-/**
- * Category section with collapsible tactic list
- */
-function CategorySection({
-  category,
-  tactics,
-  isExpanded,
-  onToggle,
-}: {
-  category: TacticCategory;
-  tactics: TacticInfo[];
-  isExpanded: boolean;
-  onToggle: () => void;
-}) {
-  return (
-    <div className="rounded border bg-white">
-      {/* Category header */}
-      <button
-        onClick={onToggle}
-        className="flex w-full items-center justify-between p-2 text-left hover:bg-gray-50"
-      >
-        <span className="text-xs font-medium text-gray-700">
-          {CATEGORY_NAMES[category]}
+    <>
+      <div className="pe-panel-head">
+        <h3>Tactics</h3>
+        <div style={{ flex: 1 }} />
+        <span style={{ fontFamily: 'var(--pe-mono-font)', fontSize: 10.5, color: 'var(--pe-faint)' }}>
+          drag →
         </span>
-        <svg
-          className={cn(
-            'h-4 w-4 text-gray-400 transition-transform',
-            isExpanded && 'rotate-180'
-          )}
-          fill="none"
-          viewBox="0 0 24 24"
-          stroke="currentColor"
-        >
-          <path
-            strokeLinecap="round"
-            strokeLinejoin="round"
-            strokeWidth={2}
-            d="M19 9l-7 7-7-7"
-          />
-        </svg>
-      </button>
+      </div>
 
-      {/* Tactic list */}
-      {isExpanded && (
-        <div className="border-t px-1 py-1 space-y-0.5">
-          {tactics.map((tactic) => (
-            <DraggableTactic key={tactic.type} tactic={tactic} />
+      <div className="pe-tactics-body">
+        {(Object.keys(tacticsByCategory) as TacticCategory[])
+          .filter((cat) => tacticsByCategory[cat]?.length > 0)
+          .map((category) => (
+            <div key={category} className="pe-t-cat">
+              <div className="pe-t-cat-head">
+                <span className="label">{CATEGORY_NAMES[category]}</span>
+                <span className="count">{tacticsByCategory[category].length}</span>
+              </div>
+              {tacticsByCategory[category].map((tactic) => (
+                <DraggableTactic key={tactic.type} tactic={tactic} />
+              ))}
+            </div>
           ))}
-        </div>
-      )}
-    </div>
+      </div>
+    </>
   );
 }
 
-/**
- * Individual draggable tactic item
- */
 function DraggableTactic({ tactic }: { tactic: TacticInfo }) {
   const setDraggingTactic = useUIStore((s) => s.setDraggingTactic);
   const clearDragState = useUIStore((s) => s.clearDragState);
 
   const handleDragStart = (e: React.DragEvent) => {
-    // Set the tactic type as drag data
     e.dataTransfer.setData('application/tactic-type', tactic.type);
     e.dataTransfer.effectAllowed = 'copy';
     setDraggingTactic(tactic.type);
@@ -133,34 +86,12 @@ function DraggableTactic({ tactic }: { tactic: TacticInfo }) {
       draggable
       onDragStart={handleDragStart}
       onDragEnd={handleDragEnd}
-      className={cn(
-        'group flex items-center gap-2 rounded px-2 py-1.5 cursor-grab',
-        'hover:bg-blue-50 active:cursor-grabbing',
-        'border border-transparent hover:border-blue-200'
-      )}
       title={tactic.description}
+      className={`pe-t-item${tactic.requiresContextVar ? ' ctx' : ''}`}
     >
-      {/* Tactic icon/badge */}
-      <span
-        className={cn(
-          'flex h-5 w-5 items-center justify-center rounded text-[10px] font-bold',
-          tactic.requiresContextVar
-            ? 'bg-purple-100 text-purple-700'
-            : 'bg-blue-100 text-blue-700'
-        )}
-      >
-        {tactic.displayName.charAt(0).toUpperCase()}
-      </span>
-
-      {/* Tactic name */}
-      <span className="text-sm font-mono">{tactic.displayName}</span>
-
-      {/* Context indicator */}
-      {tactic.requiresContextVar && (
-        <span className="ml-auto text-[10px] text-purple-500" title="Requires context variable">
-          ctx
-        </span>
-      )}
+      <span className="pe-t-glyph">{getGlyph(tactic)}</span>
+      <span className="pe-t-nm">{tactic.displayName}</span>
+      <span className="pe-t-tag">{getTag(tactic)}</span>
     </div>
   );
 }

--- a/web-react/src/features/proof-editor/components/panels/TacticPalette.tsx
+++ b/web-react/src/features/proof-editor/components/panels/TacticPalette.tsx
@@ -30,9 +30,9 @@ function getGlyph(tactic: TacticInfo): string {
   return TACTIC_GLYPH[tactic.type] ?? tactic.displayName.charAt(0).toUpperCase();
 }
 
-function getTag(tactic: TacticInfo): string {
+function getTag(tactic: TacticInfo): string | null {
   if (tactic.requiresContextVar) return 'ctx';
-  return '—';
+  return null;
 }
 
 export function TacticPalette() {
@@ -89,9 +89,9 @@ function DraggableTactic({ tactic }: { tactic: TacticInfo }) {
       title={tactic.description}
       className={`pe-t-item${tactic.requiresContextVar ? ' ctx' : ''}`}
     >
-      <span className="pe-t-glyph">{getGlyph(tactic)}</span>
+      <span className={`pe-t-glyph cat-${tactic.category}`}>{getGlyph(tactic)}</span>
       <span className="pe-t-nm">{tactic.displayName}</span>
-      <span className="pe-t-tag">{getTag(tactic)}</span>
+      {getTag(tactic) && <span className="pe-t-tag">{getTag(tactic)}</span>}
     </div>
   );
 }

--- a/web-react/src/features/proof-editor/utils/convert-proof-tree.ts
+++ b/web-react/src/features/proof-editor/utils/convert-proof-tree.ts
@@ -1,3 +1,4 @@
+import dagre from "@dagrejs/dagre";
 import type {
   ProofNode,
   ProofEdge,
@@ -14,11 +15,11 @@ import type {
 } from "@pie/protocol";
 import { nanoid } from "nanoid";
 
-// Layout constants
-const NODE_WIDTH = 200;
-const NODE_HEIGHT = 120;
-const HORIZONTAL_SPACING = 50;
-const VERTICAL_SPACING = 150;
+// Node size estimates (dagre needs dimensions upfront)
+const GOAL_WIDTH = 220;
+const GOAL_HEIGHT = 130;
+const TACTIC_WIDTH = 160;
+const TACTIC_HEIGHT = 52;
 
 interface ConversionResult {
   nodes: ProofNode[];
@@ -55,96 +56,53 @@ export function convertProofTreeToReactFlow(
 }
 
 /**
- * Calculate positions for all nodes in the tree using a simple layout algorithm.
- * Returns a map from goal ID to position.
+ * Calculate positions for all nodes in the tree using dagre.
+ * Returns a map from node ID to top-left position (React Flow convention).
  */
 function calculateTreeLayout(
   root: ProtoGoalNode,
 ): Map<string, { x: number; y: number }> {
+  const g = new dagre.graphlib.Graph();
+  g.setDefaultEdgeLabel(() => ({}));
+  g.setGraph({ rankdir: "TB", ranksep: 60, nodesep: 40, edgesep: 10 });
+
+  // Collect all nodes and edges from the tree
+  function collectNodes(node: ProtoGoalNode) {
+    g.setNode(node.goal.id, { width: GOAL_WIDTH, height: GOAL_HEIGHT });
+
+    if (node.appliedTactic && node.children.length > 0) {
+      const tacticId = `tactic-for-${node.goal.id}`;
+      g.setNode(tacticId, { width: TACTIC_WIDTH, height: TACTIC_HEIGHT });
+      g.setEdge(node.goal.id, tacticId);
+      for (const child of node.children) {
+        g.setEdge(tacticId, child.goal.id);
+        collectNodes(child);
+      }
+    } else if (node.completedBy && node.children.length === 0) {
+      const tacticId = `tactic-completing-${node.goal.id}`;
+      g.setNode(tacticId, { width: TACTIC_WIDTH, height: TACTIC_HEIGHT });
+      g.setEdge(node.goal.id, tacticId);
+    } else {
+      for (const child of node.children) {
+        g.setEdge(node.goal.id, child.goal.id);
+        collectNodes(child);
+      }
+    }
+  }
+
+  collectNodes(root);
+  dagre.layout(g);
+
+  // Dagre positions are node centers — convert to top-left for React Flow
   const positions = new Map<string, { x: number; y: number }>();
-
-  // First pass: calculate subtree widths
-  const widths = new Map<string, number>();
-  calculateSubtreeWidths(root, widths);
-
-  // Second pass: assign positions
-  assignPositions(root, 0, 0, widths, positions);
+  g.nodes().forEach((id) => {
+    const n = g.node(id);
+    if (n) {
+      positions.set(id, { x: n.x - n.width / 2, y: n.y - n.height / 2 });
+    }
+  });
 
   return positions;
-}
-
-/**
- * Calculate the width of each subtree (for horizontal spacing)
- */
-function calculateSubtreeWidths(
-  node: ProtoGoalNode,
-  widths: Map<string, number>,
-): number {
-  if (node.children.length === 0) {
-    const width = NODE_WIDTH;
-    widths.set(node.goal.id, width);
-    return width;
-  }
-
-  let totalWidth = 0;
-  for (const child of node.children) {
-    totalWidth += calculateSubtreeWidths(child, widths);
-  }
-  // Add spacing between children
-  totalWidth += (node.children.length - 1) * HORIZONTAL_SPACING;
-
-  // Width is at least the node width
-  const width = Math.max(NODE_WIDTH, totalWidth);
-  widths.set(node.goal.id, width);
-  return width;
-}
-
-/**
- * Assign positions to nodes based on their subtree widths
- */
-function assignPositions(
-  node: ProtoGoalNode,
-  x: number,
-  y: number,
-  widths: Map<string, number>,
-  positions: Map<string, { x: number; y: number }>,
-): void {
-  const nodeWidth = widths.get(node.goal.id) || NODE_WIDTH;
-
-  // Center this node within its allocated space
-  const nodeX = x + nodeWidth / 2 - NODE_WIDTH / 2;
-  positions.set(node.goal.id, { x: nodeX, y });
-
-  if (node.children.length === 0) return;
-
-  // Position children below, with tactic node in between
-  const tacticY = y + NODE_HEIGHT + VERTICAL_SPACING / 2;
-  const childrenY = y + NODE_HEIGHT + VERTICAL_SPACING;
-
-  // Calculate starting x for children
-  let childX = x;
-  const totalChildrenWidth =
-    node.children.reduce(
-      (sum, child) => sum + (widths.get(child.goal.id) || NODE_WIDTH),
-      0,
-    ) +
-    (node.children.length - 1) * HORIZONTAL_SPACING;
-
-  // Center children under parent
-  childX = x + (nodeWidth - totalChildrenWidth) / 2;
-
-  // Store tactic position (centered between this node and children)
-  if (node.appliedTactic) {
-    const tacticId = `tactic-for-${node.goal.id}`;
-    positions.set(tacticId, { x: nodeX, y: tacticY });
-  }
-
-  // Position each child
-  for (const child of node.children) {
-    const childWidth = widths.get(child.goal.id) || NODE_WIDTH;
-    assignPositions(child, childX, childrenY, widths, positions);
-    childX += childWidth + HORIZONTAL_SPACING;
-  }
 }
 
 /**
@@ -197,7 +155,7 @@ function traverseTree(
     const tacticId = `tactic-for-${node.goal.id}`;
     const tacticPosition = positions.get(tacticId) || {
       x: position.x,
-      y: position.y + NODE_HEIGHT + VERTICAL_SPACING / 2,
+      y: position.y + GOAL_HEIGHT + 40,
     };
 
     const tacticNode: TacticNode = {
@@ -239,7 +197,7 @@ function traverseTree(
     const tacticId = `tactic-completing-${node.goal.id}`;
     const tacticPosition = {
       x: position.x,
-      y: position.y + NODE_HEIGHT + 50,
+      y: position.y + GOAL_HEIGHT + 40,
     };
 
     const tacticNode: TacticNode = {

--- a/web-react/src/shared/styles/globals.css
+++ b/web-react/src/shared/styles/globals.css
@@ -276,7 +276,7 @@
 }
 
 .pe-main.source-collapsed {
-  grid-template-columns: 36px 170px minmax(0, 1fr) 260px;
+  grid-template-columns: 20px 170px minmax(0, 1fr) 260px;
 }
 
 .pe-main.source-collapsed > section.pe-source {
@@ -285,11 +285,11 @@
 
 @media (max-width: 1240px) {
   .pe-main { grid-template-columns: 300px 160px minmax(0, 1fr) 240px; }
-  .pe-main.source-collapsed { grid-template-columns: 36px 160px minmax(0, 1fr) 240px; }
+  .pe-main.source-collapsed { grid-template-columns: 20px 160px minmax(0, 1fr) 240px; }
 }
 
 @media (max-width: 1100px) {
-  .pe-main { grid-template-columns: 36px 160px minmax(0, 1fr) 240px; }
+  .pe-main { grid-template-columns: 20px 160px minmax(0, 1fr) 240px; }
   .pe-main > section.pe-source { display: none; }
   .pe-source-stub { display: flex !important; }
 }
@@ -305,14 +305,18 @@
   display: none;
   background: var(--pe-surface);
   border-right: 1px solid var(--pe-line);
-  padding: 10px 0;
+  padding: 0;
   cursor: pointer;
   color: var(--pe-muted);
   flex-direction: column;
   align-items: center;
-  gap: 10px;
+  justify-content: flex-start;
+  gap: 0;
   min-width: 0;
   border: none;
+  width: 20px;
+  /* top padding matches panel-head height so icon lands at same y as < button */
+  padding-top: 9px;
 }
 
 .pe-source-stub:hover {
@@ -665,10 +669,31 @@
   flex-shrink: 0;
 }
 
-.pe-t-item.ctx .pe-t-glyph {
-  background: color-mix(in oklab, var(--pe-accent) 10%, white);
-  color: var(--pe-accent);
-  border-color: color-mix(in oklab, var(--pe-accent) 22%, white);
+/* Category colours for glyph badges */
+.pe-t-glyph.cat-introduction {
+  background: #eff6ff;
+  color: #2563eb;
+  border-color: #bfdbfe;
+}
+.pe-t-glyph.cat-constructor {
+  background: #f0fdf4;
+  color: #16a34a;
+  border-color: #bbf7d0;
+}
+.pe-t-glyph.cat-elimination {
+  background: #faf5ff;
+  color: #7c3aed;
+  border-color: #e9d5ff;
+}
+.pe-t-glyph.cat-application {
+  background: #fff7ed;
+  color: #ea580c;
+  border-color: #fed7aa;
+}
+.pe-t-glyph.cat-placeholder {
+  background: #f8fafc;
+  color: #64748b;
+  border-color: #cbd5e1;
 }
 
 .pe-t-nm {

--- a/web-react/src/shared/styles/globals.css
+++ b/web-react/src/shared/styles/globals.css
@@ -2,6 +2,7 @@
 @tailwind components;
 @tailwind utilities;
 
+/* ============ SHADCN / TAILWIND TOKENS ============ */
 :root {
   --background: 0 0% 100%;
   --foreground: 222.2 84% 4.9%;
@@ -25,6 +26,38 @@
   --radius: 0.5rem;
 }
 
+/* ============ PIE EDITOR DESIGN TOKENS ============ */
+:root {
+  --pe-bg: #f7f7f5;
+  --pe-surface: #ffffff;
+  --pe-surface-2: #fbfbf9;
+  --pe-surface-sunk: #f2f2ee;
+  --pe-ink: #111418;
+  --pe-ink-2: #3a4049;
+  --pe-muted: #6b7280;
+  --pe-faint: #9aa0a6;
+  --pe-line: #e7e5df;
+  --pe-line-2: #edece6;
+  --pe-accent: oklch(0.54 0.14 255);
+  --pe-accent-soft: oklch(0.96 0.025 255);
+  --pe-ok: #0f8a5a;
+  --pe-ok-soft: #e7f5ed;
+  --pe-warn: #b4770f;
+  --pe-warn-soft: #fbf1d9;
+  --pe-err: #c6334b;
+  --pe-err-soft: #fbe8ec;
+  --pe-goal-pending: #c97400;
+  --pe-goal-current: #b4770f;
+  --pe-goal-complete: #0f8a5a;
+  --pe-tactic: #4363c7;
+  --pe-ui-font: 'Inter', -apple-system, BlinkMacSystemFont, 'Segoe UI', system-ui, sans-serif;
+  --pe-mono-font: 'JetBrains Mono', ui-monospace, SFMono-Regular, Menlo, Consolas, monospace;
+  --pe-radius: 6px;
+  --pe-radius-lg: 10px;
+  --pe-shadow-sm: 0 1px 0 rgba(17, 20, 24, 0.04);
+  --pe-shadow-md: 0 1px 2px rgba(17, 20, 24, 0.06), 0 4px 12px rgba(17, 20, 24, 0.04);
+}
+
 @layer base {
   * {
     @apply border-border;
@@ -32,5 +65,955 @@
 
   body {
     @apply bg-background text-foreground;
+    font-family: var(--pe-ui-font);
+    font-size: 13px;
+    -webkit-font-smoothing: antialiased;
   }
+}
+
+/* ============ PIE EDITOR LAYOUT ============ */
+.pe-app {
+  display: grid;
+  grid-template-rows: 44px 1fr;
+  height: 100vh;
+  width: 100vw;
+  background: var(--pe-bg);
+  color: var(--pe-ink);
+  font-family: var(--pe-ui-font);
+  font-size: 13px;
+  line-height: 1.45;
+}
+
+/* ============ TOP BAR ============ */
+.pe-topbar {
+  display: flex;
+  align-items: center;
+  gap: 14px;
+  padding: 0 14px;
+  background: var(--pe-surface);
+  border-bottom: 1px solid var(--pe-line);
+  min-width: 0;
+  overflow: hidden;
+}
+
+.pe-sep {
+  width: 1px;
+  height: 18px;
+  background: var(--pe-line);
+  flex-shrink: 0;
+}
+
+.pe-brand {
+  display: flex;
+  align-items: center;
+  gap: 8px;
+  font-weight: 600;
+  letter-spacing: -0.2px;
+  flex-shrink: 0;
+}
+
+.pe-brand-pi {
+  display: inline-flex;
+  width: 22px;
+  height: 22px;
+  align-items: center;
+  justify-content: center;
+  background: var(--pe-ink);
+  color: #fff;
+  border-radius: 5px;
+  font-family: var(--pe-mono-font);
+  font-weight: 600;
+  font-size: 13px;
+}
+
+.pe-brand-name {
+  font-size: 13px;
+  color: var(--pe-ink);
+}
+
+.pe-brand-sub {
+  color: var(--pe-faint);
+  font-weight: 400;
+  font-size: 12px;
+}
+
+.pe-tb-label {
+  font-size: 11.5px;
+  color: var(--pe-muted);
+  flex-shrink: 0;
+}
+
+.pe-select {
+  appearance: none;
+  background: var(--pe-surface);
+  border: 1px solid var(--pe-line);
+  border-radius: 5px;
+  padding: 3px 22px 3px 8px;
+  font-size: 12px;
+  font-family: var(--pe-ui-font);
+  color: var(--pe-ink);
+  cursor: pointer;
+  background-image: url("data:image/svg+xml;utf8,<svg xmlns='http://www.w3.org/2000/svg' width='10' height='10' viewBox='0 0 10 10' fill='none' stroke='%236b7280' stroke-width='1.6'><path d='M2 4l3 3 3-3'/></svg>");
+  background-repeat: no-repeat;
+  background-position: right 6px center;
+}
+
+.pe-select:focus {
+  outline: none;
+  border-color: var(--pe-accent);
+  box-shadow: 0 0 0 3px color-mix(in oklab, var(--pe-accent) 18%, transparent);
+}
+
+.pe-session-chip {
+  display: inline-flex;
+  align-items: center;
+  gap: 7px;
+  padding: 3px 9px;
+  border: 1px solid var(--pe-line);
+  border-radius: 99px;
+  font-size: 11.5px;
+  background: var(--pe-surface);
+  max-width: 360px;
+  min-width: 0;
+  overflow: hidden;
+  white-space: nowrap;
+}
+
+.pe-session-chip > * {
+  flex-shrink: 0;
+}
+
+.pe-session-chip .chip-expr {
+  min-width: 0;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  flex-shrink: 1;
+  color: var(--pe-muted);
+  font-family: var(--pe-mono-font);
+  font-size: 11px;
+}
+
+.pe-session-chip .chip-dot {
+  width: 6px;
+  height: 6px;
+  border-radius: 3px;
+  background: var(--pe-ok);
+}
+
+.pe-session-chip .chip-claim {
+  font-family: var(--pe-mono-font);
+  font-weight: 500;
+  color: var(--pe-ink);
+}
+
+.pe-session-chip .chip-muted {
+  color: var(--pe-muted);
+}
+
+.pe-auto-indicator {
+  display: inline-flex;
+  align-items: center;
+  gap: 7px;
+  font-size: 11.5px;
+  color: var(--pe-muted);
+  padding: 3px 10px;
+  border-radius: 99px;
+  background: var(--pe-surface-2);
+  border: 1px solid var(--pe-line-2);
+  flex-shrink: 0;
+}
+
+.pe-pulse {
+  width: 6px;
+  height: 6px;
+  border-radius: 3px;
+  background: var(--pe-ok);
+  box-shadow: 0 0 0 0 color-mix(in oklab, var(--pe-ok) 50%, transparent);
+  animation: pe-pulse 2s ease-out infinite;
+}
+
+@keyframes pe-pulse {
+  0% { box-shadow: 0 0 0 0 color-mix(in oklab, var(--pe-ok) 45%, transparent); }
+  70% { box-shadow: 0 0 0 6px transparent; }
+  100% { box-shadow: 0 0 0 0 transparent; }
+}
+
+.pe-tb-right {
+  display: flex;
+  align-items: center;
+  gap: 8px;
+  margin-left: auto;
+  flex-shrink: 0;
+}
+
+.pe-error-pill {
+  display: inline-flex;
+  align-items: center;
+  gap: 6px;
+  padding: 3px 10px;
+  border-radius: 99px;
+  font-size: 11.5px;
+  background: var(--pe-err-soft);
+  color: var(--pe-err);
+  border: 1px solid #f5c9d1;
+}
+
+/* ============ MAIN GRID ============ */
+.pe-main {
+  display: grid;
+  grid-template-columns: 340px 170px minmax(0, 1fr) 260px;
+  min-height: 0;
+  background: var(--pe-bg);
+  overflow: hidden;
+}
+
+.pe-main > section {
+  min-width: 0;
+  min-height: 0;
+  display: flex;
+  flex-direction: column;
+  overflow: hidden;
+}
+
+.pe-main.source-collapsed {
+  grid-template-columns: 36px 170px minmax(0, 1fr) 260px;
+}
+
+.pe-main.source-collapsed > section.pe-source {
+  display: none;
+}
+
+@media (max-width: 1240px) {
+  .pe-main { grid-template-columns: 300px 160px minmax(0, 1fr) 240px; }
+  .pe-main.source-collapsed { grid-template-columns: 36px 160px minmax(0, 1fr) 240px; }
+}
+
+@media (max-width: 1100px) {
+  .pe-main { grid-template-columns: 36px 160px minmax(0, 1fr) 240px; }
+  .pe-main > section.pe-source { display: none; }
+  .pe-source-stub { display: flex !important; }
+}
+
+@media (max-width: 900px) {
+  .pe-main { grid-template-columns: 36px 160px minmax(0, 1fr); }
+  .pe-main.source-collapsed { grid-template-columns: 36px 160px minmax(0, 1fr); }
+  .pe-main > section.pe-detail { display: none; }
+}
+
+/* ============ SOURCE STUB ============ */
+.pe-source-stub {
+  display: none;
+  background: var(--pe-surface);
+  border-right: 1px solid var(--pe-line);
+  padding: 10px 0;
+  cursor: pointer;
+  color: var(--pe-muted);
+  flex-direction: column;
+  align-items: center;
+  gap: 10px;
+  min-width: 0;
+  border: none;
+}
+
+.pe-source-stub:hover {
+  background: var(--pe-surface-2);
+  color: var(--pe-ink);
+}
+
+.pe-main.source-collapsed > .pe-source-stub {
+  display: flex;
+}
+
+.pe-stub-label {
+  writing-mode: vertical-rl;
+  transform: rotate(180deg);
+  font-size: 11px;
+  font-weight: 500;
+  letter-spacing: 0.04em;
+  margin-top: 2px;
+}
+
+.pe-stub-sync {
+  margin-top: auto;
+}
+
+/* ============ SHARED PANEL PARTS ============ */
+.pe-panel-head {
+  display: flex;
+  align-items: center;
+  gap: 10px;
+  padding: 9px 14px;
+  border-bottom: 1px solid var(--pe-line-2);
+  background: var(--pe-surface);
+  flex-shrink: 0;
+}
+
+.pe-panel-head h3 {
+  margin: 0;
+  font-size: 12px;
+  font-weight: 600;
+  letter-spacing: -0.1px;
+  color: var(--pe-ink);
+}
+
+.pe-icon-btn {
+  width: 26px;
+  height: 26px;
+  border-radius: 5px;
+  border: 1px solid var(--pe-line);
+  background: var(--pe-surface);
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  color: var(--pe-muted);
+  cursor: pointer;
+  flex-shrink: 0;
+  padding: 0;
+}
+
+.pe-icon-btn:hover {
+  color: var(--pe-ink);
+  background: var(--pe-surface-2);
+}
+
+.pe-btn {
+  border: 1px solid var(--pe-line);
+  background: var(--pe-surface);
+  color: var(--pe-ink);
+  border-radius: 5px;
+  padding: 4px 10px;
+  font-size: 12px;
+  font-family: var(--pe-ui-font);
+  cursor: pointer;
+  display: inline-flex;
+  align-items: center;
+  gap: 6px;
+}
+
+.pe-btn:hover {
+  background: var(--pe-surface-2);
+}
+
+.pe-btn.primary {
+  background: var(--pe-ink);
+  color: #fff;
+  border-color: var(--pe-ink);
+}
+
+.pe-btn.primary:hover {
+  background: #222831;
+}
+
+.pe-btn:disabled {
+  opacity: 0.4;
+  cursor: not-allowed;
+}
+
+/* ============ SOURCE RAIL ============ */
+.pe-source {
+  background: var(--pe-surface);
+  border-right: 1px solid var(--pe-line);
+}
+
+.pe-sync-badge {
+  display: inline-flex;
+  align-items: center;
+  gap: 6px;
+  padding: 2px 8px;
+  border-radius: 99px;
+  font-size: 11px;
+  font-weight: 500;
+  background: var(--pe-ok-soft);
+  color: var(--pe-ok);
+  border: 1px solid #c8e6d4;
+}
+
+.pe-sync-badge .dot {
+  width: 5px;
+  height: 5px;
+  border-radius: 3px;
+  background: currentColor;
+}
+
+.pe-sync-badge.syncing {
+  background: var(--pe-accent-soft);
+  color: var(--pe-accent);
+  border-color: #c9d6f3;
+}
+
+.pe-sync-badge.edited {
+  background: var(--pe-warn-soft);
+  color: var(--pe-warn);
+  border-color: #eed8a7;
+}
+
+.pe-sync-badge.error {
+  background: var(--pe-err-soft);
+  color: var(--pe-err);
+  border-color: #f5c9d1;
+}
+
+.pe-source-claim {
+  display: flex;
+  align-items: center;
+  gap: 8px;
+  padding: 8px 14px;
+  border-bottom: 1px solid var(--pe-line-2);
+  background: var(--pe-surface-2);
+  flex-shrink: 0;
+}
+
+.pe-source-claim label {
+  font-size: 11px;
+  color: var(--pe-muted);
+  flex-shrink: 0;
+}
+
+.pe-input {
+  flex: 1;
+  border: 1px solid var(--pe-line);
+  background: var(--pe-surface);
+  border-radius: 5px;
+  padding: 4px 8px;
+  font-size: 12.5px;
+  font-family: var(--pe-mono-font);
+  color: var(--pe-ink);
+  min-width: 0;
+}
+
+.pe-input:focus {
+  outline: none;
+  border-color: var(--pe-accent);
+  box-shadow: 0 0 0 3px color-mix(in oklab, var(--pe-accent) 18%, transparent);
+}
+
+.pe-editor-frame {
+  flex: 1;
+  display: flex;
+  flex-direction: column;
+  min-height: 0;
+  background: #1b1d22;
+  position: relative;
+}
+
+.pe-gutter-info {
+  position: absolute;
+  top: 8px;
+  right: 10px;
+  font-family: var(--pe-mono-font);
+  font-size: 10.5px;
+  color: #6b7280;
+  z-index: 2;
+  pointer-events: none;
+}
+
+.pe-diag-strip {
+  border-top: 1px solid var(--pe-line);
+  background: var(--pe-surface);
+  max-height: 140px;
+  overflow: auto;
+  flex-shrink: 0;
+}
+
+.pe-diag-head {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  padding: 7px 14px;
+  border-bottom: 1px solid var(--pe-line-2);
+}
+
+.pe-diag-head .title {
+  font-size: 11px;
+  color: var(--pe-muted);
+  display: flex;
+  align-items: center;
+  gap: 8px;
+}
+
+.pe-diag-ok {
+  padding: 9px 14px;
+  font-size: 11.5px;
+  color: var(--pe-ok);
+  display: flex;
+  align-items: center;
+  gap: 7px;
+}
+
+.pe-diag-ok .dot {
+  width: 6px;
+  height: 6px;
+  border-radius: 3px;
+  background: var(--pe-ok);
+}
+
+.pe-diag-list {
+  list-style: none;
+  margin: 0;
+  padding: 2px 0;
+}
+
+.pe-diag-row {
+  display: grid;
+  grid-template-columns: 12px 44px 1fr;
+  gap: 10px;
+  align-items: start;
+  padding: 4px 14px;
+  font-size: 11.5px;
+}
+
+.pe-diag-row:hover {
+  background: var(--pe-surface-2);
+}
+
+.pe-diag-row .sev {
+  width: 8px;
+  height: 8px;
+  border-radius: 4px;
+  margin-top: 4px;
+}
+
+.pe-diag-row.err .sev { background: var(--pe-err); }
+.pe-diag-row.warn .sev { background: var(--pe-warn); }
+
+.pe-diag-row .loc {
+  font-family: var(--pe-mono-font);
+  color: var(--pe-muted);
+  font-size: 11px;
+}
+
+.pe-diag-row .msg {
+  font-family: var(--pe-mono-font);
+  color: var(--pe-ink-2);
+}
+
+.pe-diag-row.err .msg { color: var(--pe-err); }
+
+/* ============ TACTIC RAIL ============ */
+.pe-tactics {
+  background: var(--pe-surface);
+  border-right: 1px solid var(--pe-line);
+}
+
+.pe-tactics-body {
+  flex: 1;
+  overflow: auto;
+  padding: 8px 10px;
+}
+
+.pe-t-cat {
+  margin-bottom: 12px;
+}
+
+.pe-t-cat-head {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  padding: 4px 4px 6px;
+  border-bottom: 1px solid var(--pe-line-2);
+  margin-bottom: 6px;
+}
+
+.pe-t-cat-head .label {
+  font-size: 10.5px;
+  letter-spacing: 0.08em;
+  text-transform: uppercase;
+  color: var(--pe-faint);
+  font-weight: 600;
+}
+
+.pe-t-cat-head .count {
+  font-family: var(--pe-mono-font);
+  font-size: 10.5px;
+  color: var(--pe-faint);
+}
+
+.pe-t-item {
+  display: grid;
+  grid-template-columns: 20px 1fr auto;
+  gap: 8px;
+  align-items: center;
+  padding: 5px 6px;
+  border-radius: 5px;
+  cursor: grab;
+  border: 1px solid transparent;
+  user-select: none;
+}
+
+.pe-t-item:hover {
+  background: var(--pe-surface-2);
+  border-color: var(--pe-line-2);
+}
+
+.pe-t-item:active {
+  cursor: grabbing;
+}
+
+.pe-t-glyph {
+  width: 20px;
+  height: 20px;
+  border-radius: 4px;
+  background: var(--pe-surface-sunk);
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  font-family: var(--pe-mono-font);
+  font-weight: 600;
+  font-size: 11px;
+  color: var(--pe-ink-2);
+  border: 1px solid var(--pe-line-2);
+  flex-shrink: 0;
+}
+
+.pe-t-item.ctx .pe-t-glyph {
+  background: color-mix(in oklab, var(--pe-accent) 10%, white);
+  color: var(--pe-accent);
+  border-color: color-mix(in oklab, var(--pe-accent) 22%, white);
+}
+
+.pe-t-nm {
+  font-family: var(--pe-mono-font);
+  font-size: 12px;
+  color: var(--pe-ink);
+  white-space: nowrap;
+  overflow: hidden;
+  text-overflow: ellipsis;
+}
+
+.pe-t-tag {
+  font-size: 9.5px;
+  color: var(--pe-faint);
+  font-family: var(--pe-mono-font);
+  padding: 1px 5px;
+  border: 1px solid var(--pe-line-2);
+  border-radius: 99px;
+  white-space: nowrap;
+}
+
+.pe-t-item:hover .pe-t-tag {
+  color: var(--pe-muted);
+}
+
+/* ============ CANVAS ============ */
+.pe-canvas-wrap {
+  background: var(--pe-bg);
+  position: relative;
+  display: flex;
+  flex-direction: column;
+}
+
+.pe-canvas-head {
+  display: flex;
+  align-items: center;
+  gap: 10px;
+  padding: 8px 14px;
+  background: var(--pe-surface);
+  border-bottom: 1px solid var(--pe-line);
+  min-width: 0;
+  overflow: hidden;
+  flex-shrink: 0;
+}
+
+.pe-breadcrumb {
+  font-family: var(--pe-mono-font);
+  font-size: 11.5px;
+  color: var(--pe-muted);
+  display: flex;
+  align-items: center;
+  gap: 6px;
+  min-width: 0;
+  overflow: hidden;
+  white-space: nowrap;
+  flex-shrink: 1;
+}
+
+.pe-breadcrumb > * { flex-shrink: 0; }
+
+.pe-breadcrumb .cur {
+  overflow: hidden;
+  text-overflow: ellipsis;
+  flex-shrink: 1;
+  color: var(--pe-ink);
+  font-weight: 500;
+}
+
+.pe-canvas-actions {
+  display: flex;
+  align-items: center;
+  gap: 4px;
+}
+
+.pe-canvas-status {
+  display: flex;
+  align-items: center;
+  gap: 14px;
+  padding: 5px 14px;
+  background: var(--pe-surface);
+  border-top: 1px solid var(--pe-line);
+  font-family: var(--pe-mono-font);
+  font-size: 11px;
+  color: var(--pe-muted);
+  flex-shrink: 0;
+}
+
+.pe-cs-item {
+  display: inline-flex;
+  align-items: center;
+  gap: 5px;
+}
+
+.pe-cs-dot {
+  width: 5px;
+  height: 5px;
+  border-radius: 3px;
+  background: var(--pe-ok);
+}
+
+/* ============ DETAIL RAIL ============ */
+.pe-detail {
+  background: var(--pe-surface);
+  border-left: 1px solid var(--pe-line);
+}
+
+.pe-detail-tabs {
+  display: flex;
+  gap: 0;
+  border-bottom: 1px solid var(--pe-line);
+  background: var(--pe-surface);
+  flex-shrink: 0;
+}
+
+.pe-detail-tab {
+  flex: 1;
+  background: transparent;
+  border: none;
+  border-bottom: 2px solid transparent;
+  padding: 9px 8px;
+  font-size: 11.5px;
+  font-family: var(--pe-ui-font);
+  color: var(--pe-muted);
+  cursor: pointer;
+  letter-spacing: 0.02em;
+}
+
+.pe-detail-tab.active {
+  color: var(--pe-ink);
+  border-bottom-color: var(--pe-accent);
+  font-weight: 500;
+}
+
+.pe-detail-tab:hover:not(.active) {
+  color: var(--pe-ink-2);
+  background: var(--pe-surface-2);
+}
+
+.pe-detail-body {
+  flex: 1;
+  overflow: auto;
+}
+
+.pe-d-section {
+  padding: 12px 14px;
+  border-bottom: 1px solid var(--pe-line-2);
+}
+
+.pe-d-section:last-child {
+  border-bottom: none;
+}
+
+.pe-d-section-hd {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  margin-bottom: 8px;
+}
+
+.pe-d-section-label {
+  font-size: 10.5px;
+  letter-spacing: 0.08em;
+  text-transform: uppercase;
+  color: var(--pe-faint);
+  font-weight: 600;
+}
+
+.pe-d-section-count {
+  font-family: var(--pe-mono-font);
+  font-size: 10.5px;
+  color: var(--pe-faint);
+}
+
+.pe-big-type {
+  font-family: var(--pe-mono-font);
+  font-size: 13px;
+  background: var(--pe-surface-sunk);
+  border: 1px solid var(--pe-line-2);
+  border-radius: 6px;
+  padding: 10px 12px;
+  color: var(--pe-ink);
+  line-height: 1.5;
+  word-break: break-word;
+}
+
+.pe-meta {
+  display: flex;
+  gap: 14px;
+  margin-top: 10px;
+  font-size: 11.5px;
+  color: var(--pe-muted);
+}
+
+.pe-meta b {
+  color: var(--pe-ink);
+  font-weight: 500;
+}
+
+.pe-suggested {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 6px;
+}
+
+.pe-chip {
+  font-family: var(--pe-mono-font);
+  font-size: 11px;
+  padding: 3px 9px;
+  background: var(--pe-surface-2);
+  border: 1px solid var(--pe-line);
+  border-radius: 99px;
+  color: var(--pe-ink);
+  cursor: pointer;
+  white-space: nowrap;
+}
+
+.pe-chip:hover {
+  border-color: var(--pe-accent);
+  color: var(--pe-accent);
+}
+
+.pe-d-row {
+  display: flex;
+  align-items: center;
+  gap: 8px;
+  padding: 4px 6px;
+  border-radius: 5px;
+  cursor: pointer;
+}
+
+.pe-d-row:hover {
+  background: var(--pe-surface-2);
+}
+
+.pe-d-row.active {
+  background: var(--pe-accent-soft);
+}
+
+.pe-kindtag {
+  font-family: var(--pe-mono-font);
+  font-size: 9.5px;
+  padding: 1px 5px;
+  border-radius: 3px;
+  background: var(--pe-surface-sunk);
+  color: var(--pe-muted);
+  border: 1px solid var(--pe-line-2);
+  flex-shrink: 0;
+}
+
+.pe-kindtag.def {
+  color: #7b3ff2;
+  background: #f3edfd;
+  border-color: #e2d5f9;
+}
+
+.pe-kindtag.thm {
+  color: var(--pe-ok);
+  background: var(--pe-ok-soft);
+  border-color: #c8e6d4;
+}
+
+.pe-kindtag.claim {
+  color: var(--pe-warn);
+  background: var(--pe-warn-soft);
+  border-color: #eed8a7;
+}
+
+.pe-d-name {
+  font-family: var(--pe-mono-font);
+  font-size: 12px;
+  color: var(--pe-ink);
+}
+
+.pe-d-type {
+  font-family: var(--pe-mono-font);
+  font-size: 10.5px;
+  color: var(--pe-faint);
+  margin-left: auto;
+  max-width: 100px;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}
+
+.pe-ctx-row {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  background: var(--pe-surface);
+  border: 1px solid var(--pe-line-2);
+  border-radius: 5px;
+  padding: 4px 8px;
+  margin-bottom: 4px;
+  font-family: var(--pe-mono-font);
+  font-size: 11.5px;
+}
+
+.pe-ctx-row:last-child {
+  margin-bottom: 0;
+}
+
+.pe-ctx-var {
+  color: var(--pe-accent);
+  font-weight: 600;
+}
+
+.pe-ctx-type {
+  color: var(--pe-muted);
+}
+
+/* ============ AI SETTINGS MODAL ============ */
+.pe-modal-overlay {
+  position: fixed;
+  inset: 0;
+  background: rgba(17, 20, 24, 0.4);
+  z-index: 40;
+  display: flex;
+  align-items: flex-start;
+  justify-content: flex-end;
+  padding: 54px 14px 0;
+}
+
+.pe-modal-panel {
+  background: var(--pe-surface);
+  border: 1px solid var(--pe-line);
+  border-radius: var(--pe-radius-lg);
+  box-shadow: 0 16px 48px rgba(17, 20, 24, 0.14);
+  width: 320px;
+  overflow: hidden;
+}
+
+.pe-modal-head {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  padding: 12px 16px;
+  border-bottom: 1px solid var(--pe-line-2);
+}
+
+.pe-modal-head h3 {
+  margin: 0;
+  font-size: 13px;
+  font-weight: 600;
+}
+
+.pe-modal-body {
+  padding: 12px 16px;
 }


### PR DESCRIPTION
In response to #130 

## Summary

- Replace hand-written tree layout with dagre for proper automatic node spacing — sibling branches no longer overlap
- Add functional zoom +/−/fit floating controls inside the canvas (replacing the broken React Flow `<Controls />` overlap)
- Remove non-functional auto-layout and fit-view buttons from canvas header; keep only AI hints button
- Add per-category colour coding to tactic palette glyph badges (blue/green/purple/orange/gray)
- Remove redundant UI elements: bottom status bar, claim name from breadcrumb, UTF-8 label, auto-sync indicator
- MiniMap now only renders when node count > 8
- Slim the source panel collapse stub to a 20px chevron-only strip
- Soften edge routing with `borderRadius` on smoothstep paths
- UX polish: vertical Source label + hide connected handles on nodes
- Fix source panel toggle: single button at consistent position for expand/collapse
- Fix Reset Layout button overlapping ReactFlow zoom controls

## Merge order

**Depends on:** nothing — merge this **first**.

**Depended on by:** #172, #188, #187, #190, #191 must all be merged after this.

Recommended merge order for all related PRs:
**`#174`** → `#172` → `#188` → `#187` → `#190` → `#191`

> **No conflicts** — this is a fast-forward from `ai-visual`.

## AI Declaration

This UI redesign was designed and generated with the assistance of **Claude (Opus 4.7)** by Anthropic.