### PR TITLE
Fix AI visual proof editor bugs

### DIFF
--- a/package.json
+++ b/package.json
@@ -14,7 +14,7 @@
     "url": "https://github.com/source-academy/"
   },
   "license": "Apache-2.0",
-  "main": "dist/index.ts",
+  "main": "dist/index.js",
   "files": [
     "dist/index.js"
   ],

--- a/package.json
+++ b/package.json
@@ -55,8 +55,6 @@
   },
   "dependencies": {
     "@google/genai": "^1.25.0",
-    "@google/generative-ai": "^0.24.1",
-    "blockly": "^10.4.3",
     "conductor": "https://github.com/source-academy/conductor.git#0.3.0",
     "dotenv": "^17.2.3",
     "js-base64": "^3.7.8"

--- a/src/pie-interpreter/__tests__/test-tactics-usability.ts
+++ b/src/pie-interpreter/__tests__/test-tactics-usability.ts
@@ -245,6 +245,24 @@ describe("Tactic Usability Tests", () => {
       expect(output).toContain("10: Nat");
       expect(output).toContain("20: Nat");
     });
+
+    it("updates dependent cdr goal from the proven car term", () => {
+      const str = `
+(claim dependent-pair-proof
+  (Σ ((x Nat))
+    (= Nat x x)))
+
+(define-tactically dependent-pair-proof
+  ((split-Pair)
+   (then (exact 0))
+   (then (exact (same 0)))))
+
+(car dependent-pair-proof)
+`;
+      const output = evaluatePie(str);
+      expect(output).toContain("dependent-pair-proof");
+      expect(output).toContain("0: Nat");
+    });
   });
 
   describe("EliminateListTactic", () => {

--- a/src/pie-interpreter/__tests__/test-todo-context.ts
+++ b/src/pie-interpreter/__tests__/test-todo-context.ts
@@ -1,0 +1,43 @@
+import 'jest';
+import * as C from '../types/core';
+import { readBackContext, bindFree } from '../utils/context';
+import * as V from '../types/value';
+import { clearQueue, todoQueue } from '../solver/todo-solver';
+import { deserializeSerializableContext, PieInfoHook } from '../typechecker/utils';
+import { Location, Syntax } from '../utils/locations';
+import { Position } from '../../scheme-parser/transpiler/types/location';
+
+const testLocation = new Location(
+  new Syntax(
+    new Position(1, 1),
+    new Position(1, 5),
+    'test.pie',
+  ),
+  true,
+);
+
+describe('TODO context capture', () => {
+  beforeEach(() => {
+    clearQueue();
+  });
+
+  it('deserializes free variables from SerializableContext', () => {
+    const ctx = bindFree(new Map(), 'x', new V.Nat());
+    const serialized = readBackContext(ctx);
+    const restored = deserializeSerializableContext(serialized);
+
+    expect(restored.has('x')).toBe(true);
+    expect(restored.get('x')?.type.prettyPrint()).toBe('Nat');
+  });
+
+  it('queues TODOs with the in-scope context', () => {
+    const ctx = bindFree(new Map(), 'x', new V.Nat());
+    const serialized = readBackContext(ctx);
+
+    PieInfoHook(testLocation, ['TODO', serialized, new C.Nat(), new Map()]);
+
+    expect(todoQueue).toHaveLength(1);
+    expect(todoQueue[0].context.has('x')).toBe(true);
+    expect(todoQueue[0].expectedType.prettyPrint()).toBe('Nat');
+  });
+});

--- a/src/pie-interpreter/__tests__/test-todo-context.ts
+++ b/src/pie-interpreter/__tests__/test-todo-context.ts
@@ -1,4 +1,3 @@
-import 'jest';
 import * as C from '../types/core';
 import { readBackContext, bindFree } from '../utils/context';
 import * as V from '../types/value';

--- a/src/pie-interpreter/protocol.ts
+++ b/src/pie-interpreter/protocol.ts
@@ -112,7 +112,7 @@ export interface TacticParams {
  * Use this to validate before sending a request.
  */
 export const TACTIC_REQUIREMENTS: Record<TacticType, { variableName?: boolean; expression?: boolean }> = {
-  intro:       { variableName: false }, // optional: auto-generated if omitted
+  intro:       { variableName: true },
   exact:       { expression: true },
   exists:      { expression: true, variableName: false },
   split:       {},

--- a/src/pie-interpreter/tactics/proofstate.ts
+++ b/src/pie-interpreter/tactics/proofstate.ts
@@ -1,4 +1,4 @@
-import { Claim, Context, extendContext } from '../utils/context';
+import { Claim, Context, Define, extendContext } from '../utils/context';
 import { Core } from '../types/core';
 import { Value } from '../types/value';
 import { Location } from '../utils/locations';
@@ -65,7 +65,6 @@ export class Goal {
     const expandedType = typeCore.prettyPrint();
 
     // Debug: Check what's in the context
-    const { Define } = require('../utils/context');
     const contextDefines = Array.from(this.context.entries())
       .filter(([_, binder]) => binder instanceof Define)
       .map(([name]) => name);
@@ -125,6 +124,7 @@ export class GoalNode {
   public childFocusIndex: number = -1;
   public appliedTactic?: AppliedTactic;  // Tactic that was applied to create children
   public completedBy?: AppliedTactic;    // Tactic that directly solved this goal (for leaf nodes)
+  public onChildComplete?: (parent: GoalNode, completedChildIndex: number) => void;
   // Term builder: takes child terms and produces the term for this node
   public termBuilder?: TermBuilder;
 
@@ -315,7 +315,9 @@ export class ProofState {
         return this.nextGoalAux(curParent.parent);
       }
     } else {
+      const completedChildIndex = curParent.childFocusIndex;
       curParent.childFocusIndex += 1;
+      curParent.onChildComplete?.(curParent, completedChildIndex);
       return curParent.children[curParent.childFocusIndex];
     }
   }

--- a/src/pie-interpreter/tactics/proofstate.ts
+++ b/src/pie-interpreter/tactics/proofstate.ts
@@ -1,4 +1,4 @@
-import { Claim, Context, Define, extendContext } from '../utils/context';
+import { Claim, Context, extendContext } from '../utils/context';
 import { Core } from '../types/core';
 import { Value } from '../types/value';
 import { Location } from '../utils/locations';
@@ -64,15 +64,7 @@ export class Goal {
     const typeCore = this.type.readBackType(this.context);
     const expandedType = typeCore.prettyPrint();
 
-    // Debug: Check what's in the context
-    const contextDefines = Array.from(this.context.entries())
-      .filter(([_, binder]) => binder instanceof Define)
-      .map(([name]) => name);
-    console.log('[Goal.toSerializable] Context defines:', contextDefines);
-    console.log('[Goal.toSerializable] Type to sugar:', expandedType.substring(0, 100));
-
     const sugaredType = sugarType(typeCore, this.context);
-    console.log('[Goal.toSerializable] Sugared result:', sugaredType);
 
     return {
       id: this.id,
@@ -124,7 +116,7 @@ export class GoalNode {
   public childFocusIndex: number = -1;
   public appliedTactic?: AppliedTactic;  // Tactic that was applied to create children
   public completedBy?: AppliedTactic;    // Tactic that directly solved this goal (for leaf nodes)
-  public onChildComplete?: (parent: GoalNode, completedChildIndex: number) => void;
+  public refreshChildGoals?: (parent: GoalNode) => void;
   // Term builder: takes child terms and produces the term for this node
   public termBuilder?: TermBuilder;
 
@@ -315,9 +307,8 @@ export class ProofState {
         return this.nextGoalAux(curParent.parent);
       }
     } else {
-      const completedChildIndex = curParent.childFocusIndex;
       curParent.childFocusIndex += 1;
-      curParent.onChildComplete?.(curParent, completedChildIndex);
+      curParent.refreshChildGoals?.(curParent);
       return curParent.children[curParent.childFocusIndex];
     }
   }
@@ -371,6 +362,7 @@ export class ProofState {
   setCurrentGoalById(goalId: string): boolean {
     const found = this.findGoalById(this.goalTree, goalId);
     if (found) {
+      found.parent?.refreshChildGoals?.(found.parent);
       this.currentGoal = found;
       return true;
     }

--- a/src/pie-interpreter/tactics/tactics.ts
+++ b/src/pie-interpreter/tactics/tactics.ts
@@ -932,7 +932,7 @@ export class SpiltTactic extends Tactic {
     const pairType = currentGoal.type.now() as V.Sigma;
     const carType = pairType.carType.now();
     const cdrType = pairType.cdrType.valOfClosure(
-      pairType
+      new Neutral(carType, new Variable(pairType.carName))
     );
 
     // Set term builder: combine car and cdr into cons
@@ -940,26 +940,33 @@ export class SpiltTactic extends Tactic {
       return new C.Cons(childTerms[0], childTerms[1]);
     };
 
-    state.addGoal(
-      [
-        new GoalNode(
-          new Goal(
-            state.generateGoalId(),
-            carType,
-            currentGoal.context,
-            currentGoal.renaming
-          )
-        ),
-        new GoalNode(
-          new Goal(
-            state.generateGoalId(),
-            cdrType,
-            currentGoal.context,
-            currentGoal.renaming
-          )
-        )
-      ]
-    )
+    const carGoalNode = new GoalNode(
+      new Goal(
+        state.generateGoalId(),
+        carType,
+        currentGoal.context,
+        currentGoal.renaming
+      )
+    );
+    const cdrGoalNode = new GoalNode(
+      new Goal(
+        state.generateGoalId(),
+        cdrType,
+        currentGoal.context,
+        currentGoal.renaming
+      )
+    );
+
+    state.currentGoal.onChildComplete = (parent, completedChildIndex) => {
+      if (completedChildIndex !== 0) return;
+      const carTerm = parent.children[0]?.extractTerm();
+      const cdrGoal = parent.children[1]?.goal;
+      if (!carTerm || !cdrGoal) return;
+      const carValue = carTerm.valOf(contextToEnvironment(currentGoal.context));
+      cdrGoal.type = pairType.cdrType.valOfClosure(carValue);
+    };
+
+    state.addGoal([carGoalNode, cdrGoalNode])
     return new go(state);
   }
 }

--- a/src/pie-interpreter/tactics/tactics.ts
+++ b/src/pie-interpreter/tactics/tactics.ts
@@ -957,8 +957,7 @@ export class SpiltTactic extends Tactic {
       )
     );
 
-    state.currentGoal.onChildComplete = (parent, completedChildIndex) => {
-      if (completedChildIndex !== 0) return;
+    state.currentGoal.refreshChildGoals = (parent) => {
       const carTerm = parent.children[0]?.extractTerm();
       const cdrGoal = parent.children[1]?.goal;
       if (!carTerm || !cdrGoal) return;

--- a/src/pie-interpreter/typechecker/utils.ts
+++ b/src/pie-interpreter/typechecker/utils.ts
@@ -3,7 +3,15 @@ import { Source } from "../types/source";
 import { Application } from "../types/source";
 import { Core } from "../types/core";
 import { Location } from "../utils/locations";
-import { Context, SerializableContext } from "../utils/context";
+import {
+  bindFree,
+  bindVal,
+  Claim,
+  Context,
+  contextToEnvironment,
+  extendContext,
+  SerializableContext,
+} from "../utils/context";
 import { go, stop, Perhaps, Message } from "../types/utils";
 import { alphaEquiv } from "../utils/alpha-eqv";
 import { readBack } from "../evaluator/utils";
@@ -17,19 +25,34 @@ type What = 'definition'
   | ['TODO', SerializableContext, Core, Renaming];
 
 
-// TODO: Implement PieInfoHook
+export function deserializeSerializableContext(serializedCtx: SerializableContext): Context {
+  let ctx: Context = new Map();
+
+  for (const [name, entry] of serializedCtx) {
+    const env = contextToEnvironment(ctx);
+    const type = entry[1].valOf(env);
+
+    if (entry[0] === 'free') {
+      ctx = bindFree(ctx, name, type);
+    } else if (entry[0] === 'def') {
+      const value = entry[2].valOf(env);
+      ctx = bindVal(ctx, name, type, value);
+    } else {
+      ctx = extendContext(ctx, name, new Claim(type));
+    }
+  }
+
+  return ctx;
+}
 
 export function PieInfoHook(where: Location, what: What): void {
   if (Array.isArray(what) && what[0] === 'TODO') {
-    const [_, serializedCtx, expectedTypeCore, renaming] = what;
+    const [, serializedCtx, expectedTypeCore, renaming] = what;
 
-    // Reconstruct the actual Context from SerializableContext
-    // For now, we'll use a simpler approach - just pass empty context
-    // TODO: Properly deserialize SerializableContext to Context
-    const ctx = new Map();
+    const ctx = deserializeSerializableContext(serializedCtx);
 
     // Convert Core type to Value for storage
-    const expectedTypeValue = expectedTypeCore.valOf(new Map());
+    const expectedTypeValue = expectedTypeCore.valOf(contextToEnvironment(ctx));
 
     // Queue for processing with real objects
     todoQueue.push({

--- a/src/pie-interpreter/types/source.ts
+++ b/src/pie-interpreter/types/source.ts
@@ -2141,7 +2141,7 @@ export class GeneralTypeConstructor extends Source {
     for (let i = 0; i < this.params.length; i++) {
       const result = this.params[i].check(ctx, renames, paramTypes[i].now())
       if (result instanceof stop) {
-        return stop
+        return result
       }
       normalized_params.push((result as go<C.Core>).result)
     }
@@ -2149,7 +2149,7 @@ export class GeneralTypeConstructor extends Source {
     for (let i = 0; i < this.indices.length; i++) {
       const result = this.indices[i].check(ctx, renames, idxTypes[i].now())
       if (result instanceof stop) {
-        return stop
+        return result
       }
       normalized_indices.push((result as go<C.Core>).result)
     }

--- a/web-react/src/app/App.tsx
+++ b/web-react/src/app/App.tsx
@@ -13,8 +13,6 @@ import { useExampleStore } from '@/features/proof-editor/store/example-store';
 import { useMetadataStore } from '@/features/proof-editor/store/metadata-store';
 import { setApplyTacticCallback, type ApplyTacticOptions } from '@/features/proof-editor/utils/tactic-callback';
 import { EXAMPLES } from '@/features/proof-editor/data/examples';
-import { ProofPicker } from '@/features/proof-editor/components/ProofPicker';
-import type { GlobalEntry } from '@pie/protocol';
 
 function AppContent() {
   const { applyTactic, error } = useProofSession();
@@ -23,9 +21,6 @@ function AppContent() {
   const setManualPosition = useProofStore((s) => s.setManualPosition);
   const [tacticError, setTacticError] = useState<string | null>(null);
   const [definitionsPanelCollapsed, setDefinitionsPanelCollapsed] = useState(false);
-  const [foundClaims, setFoundClaims] = useState<GlobalEntry[]>([]);
-  const [foundTheorems, setFoundTheorems] = useState<GlobalEntry[]>([]);
-  const [selectedProof, setSelectedProof] = useState<string | null>(null);
 
   // Use keyboard shortcuts hook
   useKeyboardShortcuts();
@@ -140,11 +135,11 @@ function AppContent() {
       <SourceCodePanel />
       {/* AI Settings panel (collapsible) */}
       <AISettingsPanel />
-      <main className="flex flex-1 overflow-hidden">
+      <main className="flex min-h-0 flex-1 overflow-x-auto overflow-y-hidden">
         {/* Tactic palette (left) */}
         <TacticPalette />
         {/* Main canvas area */}
-        <div className="flex-1">
+        <div className="min-h-0 min-w-[480px] flex-1">
           <ProofCanvas />
         </div>
         {/* Definitions panel (right sidebar) */}

--- a/web-react/src/app/App.tsx
+++ b/web-react/src/app/App.tsx
@@ -100,7 +100,7 @@ function AppContent() {
   }, [tacticError]);
 
   return (
-    <div className="flex h-screen w-screen flex-col">
+    <div className="flex h-screen w-screen flex-col overflow-y-auto">
       <header className="flex h-12 items-center border-b px-4 gap-4">
         <h1 className="text-lg font-semibold">Pie Proof Editor</h1>
 
@@ -135,7 +135,7 @@ function AppContent() {
       <SourceCodePanel />
       {/* AI Settings panel (collapsible) */}
       <AISettingsPanel />
-      <main className="flex min-h-0 flex-1 overflow-x-auto overflow-y-hidden">
+      <main className="flex min-h-[420px] flex-1 overflow-x-auto overflow-y-hidden">
         {/* Tactic palette (left) */}
         <TacticPalette />
         {/* Main canvas area */}

--- a/web-react/src/features/proof-editor/components/ProofCanvas.tsx
+++ b/web-react/src/features/proof-editor/components/ProofCanvas.tsx
@@ -308,7 +308,7 @@ export function ProofCanvas() {
 
   // Derive parameterless tactics from protocol (no variableName, no expression)
   const PARAMETERLESS_TACTICS = (Object.keys(TACTIC_REQUIREMENTS) as TacticType[])
-    .filter(t => t !== "intro" && !TACTIC_REQUIREMENTS[t].variableName && !TACTIC_REQUIREMENTS[t].expression);
+    .filter(t => !TACTIC_REQUIREMENTS[t].variableName && !TACTIC_REQUIREMENTS[t].expression);
 
   // Handle drop to create a new tactic node
   const onDrop = useCallback(
@@ -436,6 +436,7 @@ export function ProofCanvas() {
     [ghostNodes],
   );
 
+  // Fit the full canvas when a new proof session starts.
   useEffect(() => {
     if (!sessionId || !rootGoalId || nodes.length === 0) return;
 
@@ -444,7 +445,18 @@ export function ProofCanvas() {
     });
 
     return () => window.cancelAnimationFrame(frame);
-  }, [fitView, nodes.length, rootGoalId, sessionId, viewportSignature]);
+  }, [fitView, rootGoalId, sessionId]); // eslint-disable-line react-hooks/exhaustive-deps
+
+  // Gently re-fit when ghost hint nodes appear or change level.
+  useEffect(() => {
+    if (!sessionId || !viewportSignature) return;
+
+    const frame = window.requestAnimationFrame(() => {
+      void fitView({ padding: 0.3, maxZoom: 1.2, duration: 200 });
+    });
+
+    return () => window.cancelAnimationFrame(frame);
+  }, [fitView, sessionId, viewportSignature]);
 
   // Compute which nodes should be hidden due to branch collapse
   const hiddenNodeIds = useMemo(() => {

--- a/web-react/src/features/proof-editor/components/ProofCanvas.tsx
+++ b/web-react/src/features/proof-editor/components/ProofCanvas.tsx
@@ -550,6 +550,7 @@ export function ProofCanvas() {
           animated: false,
         }}
         connectionLineStyle={{ stroke: "#94a3b8", strokeWidth: 2 }}
+        connectionRadius={40}
         proOptions={{
           hideAttribution: true,
         }}

--- a/web-react/src/features/proof-editor/components/ProofCanvas.tsx
+++ b/web-react/src/features/proof-editor/components/ProofCanvas.tsx
@@ -26,6 +26,7 @@ import type { TacticType } from "@pie/protocol";
 import { TACTIC_REQUIREMENTS } from "@pie/protocol";
 import type { GhostTacticNodeData } from "./nodes/GhostTacticNode";
 import { useHintSystem } from "../hooks/useHintSystem";
+import { useAutoLayout } from "../hooks/useAutoLayout";
 import { TACTICS } from "../data/tactics";
 import { applyTactic as triggerApplyTactic } from "../utils/tactic-callback";
 
@@ -36,6 +37,10 @@ import { applyTactic as triggerApplyTactic } from "../utils/tactic-callback";
  * Renders the proof tree with custom goal, tactic, and lemma nodes.
  */
 export function ProofCanvas() {
+  // Second-pass layout: reposition nodes using actual measured sizes once
+  // React Flow has rendered them (fires after every syncFromWorker call)
+  useAutoLayout();
+
   const reactFlowWrapper = useRef<HTMLDivElement>(null);
   const { screenToFlowPosition, fitView } = useReactFlow();
 

--- a/web-react/src/features/proof-editor/components/ProofCanvas.tsx
+++ b/web-react/src/features/proof-editor/components/ProofCanvas.tsx
@@ -311,7 +311,7 @@ export function ProofCanvas() {
 
   // Derive parameterless tactics from protocol (no variableName, no expression)
   const PARAMETERLESS_TACTICS = (Object.keys(TACTIC_REQUIREMENTS) as TacticType[])
-    .filter(t => !TACTIC_REQUIREMENTS[t].variableName && !TACTIC_REQUIREMENTS[t].expression);
+    .filter(t => t !== "intro" && !TACTIC_REQUIREMENTS[t].variableName && !TACTIC_REQUIREMENTS[t].expression);
 
   // Handle drop to create a new tactic node
   const onDrop = useCallback(

--- a/web-react/src/features/proof-editor/components/ProofCanvas.tsx
+++ b/web-react/src/features/proof-editor/components/ProofCanvas.tsx
@@ -25,7 +25,6 @@ import type {
 import type { TacticType } from "@pie/protocol";
 import { TACTIC_REQUIREMENTS } from "@pie/protocol";
 import type { GhostTacticNodeData } from "./nodes/GhostTacticNode";
-import { useDemoData } from "../hooks/useDemoData";
 import { useHintSystem } from "../hooks/useHintSystem";
 import { TACTICS } from "../data/tactics";
 import { applyTactic as triggerApplyTactic } from "../utils/tactic-callback";
@@ -37,11 +36,8 @@ import { applyTactic as triggerApplyTactic } from "../utils/tactic-callback";
  * Renders the proof tree with custom goal, tactic, and lemma nodes.
  */
 export function ProofCanvas() {
-  // Initialize demo data for testing
-  useDemoData();
-
   const reactFlowWrapper = useRef<HTMLDivElement>(null);
-  const { screenToFlowPosition } = useReactFlow();
+  const { screenToFlowPosition, fitView } = useReactFlow();
 
   // State for delete confirmation dialog
   const [deleteConfirmation, setDeleteConfirmation] = useState<{
@@ -56,6 +52,7 @@ export function ProofCanvas() {
   const nodes = useProofStore((s) => s.nodes);
   const edges = useProofStore((s) => s.edges);
   const sessionId = useProofStore((s) => s.sessionId);
+  const rootGoalId = useProofStore((s) => s.rootGoalId);
   const onNodesChange = useProofStore((s) => s.onNodesChange);
   const onEdgesChange = useProofStore((s) => s.onEdgesChange);
   const storeOnConnect = useProofStore((s) => s.onConnect);
@@ -431,6 +428,24 @@ export function ProofCanvas() {
     return ghosts;
   }, [goalHints, acceptGhostNode, dismissGhostNode, getMoreDetail]);
 
+  const viewportSignature = useMemo(
+    () =>
+      ghostNodes
+        .map((ghost) => `${ghost.id}:${ghost.data.hint.level}`)
+        .join("|"),
+    [ghostNodes],
+  );
+
+  useEffect(() => {
+    if (!sessionId || !rootGoalId || nodes.length === 0) return;
+
+    const frame = window.requestAnimationFrame(() => {
+      void fitView({ padding: 0.3, maxZoom: 1.2, duration: 200 });
+    });
+
+    return () => window.cancelAnimationFrame(frame);
+  }, [fitView, nodes.length, rootGoalId, sessionId, viewportSignature]);
+
   // Compute which nodes should be hidden due to branch collapse
   const hiddenNodeIds = useMemo(() => {
     const hidden = new Set<string>();
@@ -604,7 +619,7 @@ export function ProofCanvas() {
             return "#f3f4f6";
           }}
           maskColor="rgba(0, 0, 0, 0.1)"
-          className="!bottom-24 !right-4"
+          className="!bottom-4 !right-4 !h-24 !w-32"
         />
       </ReactFlow>
 

--- a/web-react/src/features/proof-editor/components/nodes/GhostTacticNode.tsx
+++ b/web-react/src/features/proof-editor/components/nodes/GhostTacticNode.tsx
@@ -202,9 +202,13 @@ export const GhostTacticNode = memo(function GhostTacticNode({
             {/* Accept button - only show when we have a tactic */}
             {hint.tacticType && (
               <button
-                onClick={handleAccept}
+                type="button"
+                onClick={(event) => {
+                  event.stopPropagation();
+                  handleAccept();
+                }}
                 className={cn(
-                  'flex items-center gap-1 rounded px-2 py-1',
+                  'nodrag nopan flex items-center gap-1 rounded px-2 py-1',
                   'bg-green-500 text-white text-xs font-medium',
                   'hover:bg-green-600 transition-colors'
                 )}
@@ -217,9 +221,13 @@ export const GhostTacticNode = memo(function GhostTacticNode({
             {/* More detail button */}
             {canShowMore && (
               <button
-                onClick={handleMoreDetail}
+                type="button"
+                onClick={(event) => {
+                  event.stopPropagation();
+                  handleMoreDetail();
+                }}
                 className={cn(
-                  'flex items-center gap-1 rounded px-2 py-1',
+                  'nodrag nopan flex items-center gap-1 rounded px-2 py-1',
                   'bg-purple-500 text-white text-xs font-medium',
                   'hover:bg-purple-600 transition-colors'
                 )}
@@ -232,9 +240,13 @@ export const GhostTacticNode = memo(function GhostTacticNode({
 
           {/* Dismiss button */}
           <button
-            onClick={handleDismiss}
+            type="button"
+            onClick={(event) => {
+              event.stopPropagation();
+              handleDismiss();
+            }}
             className={cn(
-              'flex items-center gap-1 rounded px-2 py-1',
+              'nodrag nopan flex items-center gap-1 rounded px-2 py-1',
               'bg-gray-200 text-gray-600 text-xs',
               'hover:bg-gray-300 transition-colors'
             )}

--- a/web-react/src/features/proof-editor/components/nodes/GoalNode.tsx
+++ b/web-react/src/features/proof-editor/components/nodes/GoalNode.tsx
@@ -137,7 +137,7 @@ export const GoalNode = memo(function GoalNode({
 
       // Check if tactic needs parameters (derived from protocol)
       const reqs = TACTIC_REQUIREMENTS[tacticType as TacticType];
-      const needsVariable = reqs?.variableName === true || tacticType === "intro";
+      const needsVariable = reqs?.variableName === true;
       const needsExpression = reqs?.expression === true;
 
       if (needsVariable) {

--- a/web-react/src/features/proof-editor/components/nodes/GoalNode.tsx
+++ b/web-react/src/features/proof-editor/components/nodes/GoalNode.tsx
@@ -137,7 +137,7 @@ export const GoalNode = memo(function GoalNode({
 
       // Check if tactic needs parameters (derived from protocol)
       const reqs = TACTIC_REQUIREMENTS[tacticType as TacticType];
-      const needsVariable = reqs?.variableName === true;
+      const needsVariable = reqs?.variableName === true || tacticType === "intro";
       const needsExpression = reqs?.expression === true;
 
       if (needsVariable) {

--- a/web-react/src/features/proof-editor/components/nodes/TacticNode.tsx
+++ b/web-react/src/features/proof-editor/components/nodes/TacticNode.tsx
@@ -15,7 +15,7 @@ const CONTEXT_INPUT_TACTICS: TacticType[] = (Object.keys(TACTIC_REQUIREMENTS) as
   .filter(t => TACTIC_REQUIREMENTS[t].variableName === true);
 
 const PARAMETERLESS_TACTICS: TacticType[] = (Object.keys(TACTIC_REQUIREMENTS) as TacticType[])
-  .filter(t => !TACTIC_REQUIREMENTS[t].variableName && !TACTIC_REQUIREMENTS[t].expression);
+  .filter(t => t !== "intro" && !TACTIC_REQUIREMENTS[t].variableName && !TACTIC_REQUIREMENTS[t].expression);
 
 // Status-based styling
 const STATUS_STYLES: Record<
@@ -137,14 +137,18 @@ export const TacticNode = memo(function TacticNode({
         />
       )}
 
-      {/* Inline parameter input for exact tactic */}
-      {showInlineInput && data.tacticType === "exact" && (
-        <ExactParamInput
-          nodeId={id}
-          currentExpr={data.parameters.expression}
-          connectedGoalId={data.connectedGoalId}
-        />
-      )}
+      {/* Inline parameter input for expression-based tactics */}
+      {showInlineInput &&
+        (data.tacticType === "exact" ||
+          data.tacticType === "exists" ||
+          data.tacticType === "apply") && (
+          <ExpressionParamInput
+            nodeId={id}
+            tacticType={data.tacticType}
+            currentExpr={data.parameters.expression}
+            connectedGoalId={data.connectedGoalId}
+          />
+        )}
 
       {/* Context input indicator for elim tactics (incomplete state) */}
       {data.status === "incomplete" &&
@@ -266,14 +270,16 @@ function IntroParamInput({
 }
 
 /**
- * Inline parameter input for exact tactic
+ * Inline parameter input for expression-based tactics
  */
-function ExactParamInput({
+function ExpressionParamInput({
   nodeId,
+  tacticType,
   currentExpr,
   connectedGoalId,
 }: {
   nodeId: string;
+  tacticType: "exact" | "exists" | "apply";
   currentExpr?: string;
   connectedGoalId?: string;
 }) {
@@ -292,11 +298,11 @@ function ExactParamInput({
 
       // If already connected to a goal, trigger application
       if (connectedGoalId) {
-        console.log("[TacticNode] Params set and connected, applying exact");
-        await triggerApplyTactic(connectedGoalId, "exact", params, nodeId);
+        console.log(`[TacticNode] Params set and connected, applying ${tacticType}`);
+        await triggerApplyTactic(connectedGoalId, tacticType, params, nodeId);
       }
     }
-  }, [nodeId, value, updateNode, connectedGoalId]);
+  }, [nodeId, tacticType, value, updateNode, connectedGoalId]);
 
   return (
     <div className="mt-1 nodrag">
@@ -310,7 +316,7 @@ function ExactParamInput({
             handleSubmit();
           }
         }}
-        placeholder="expression"
+        placeholder={tacticType === "exists" ? "witness expression" : "expression"}
         className="w-full rounded border border-gray-300 px-1.5 py-0.5 text-xs font-mono focus:border-blue-400 focus:outline-none"
         autoFocus
       />

--- a/web-react/src/features/proof-editor/components/nodes/TacticNode.tsx
+++ b/web-react/src/features/proof-editor/components/nodes/TacticNode.tsx
@@ -15,7 +15,7 @@ const CONTEXT_INPUT_TACTICS: TacticType[] = (Object.keys(TACTIC_REQUIREMENTS) as
   .filter(t => TACTIC_REQUIREMENTS[t].variableName === true);
 
 const PARAMETERLESS_TACTICS: TacticType[] = (Object.keys(TACTIC_REQUIREMENTS) as TacticType[])
-  .filter(t => t !== "intro" && !TACTIC_REQUIREMENTS[t].variableName && !TACTIC_REQUIREMENTS[t].expression);
+  .filter(t => !TACTIC_REQUIREMENTS[t].variableName && !TACTIC_REQUIREMENTS[t].expression);
 
 // Status-based styling
 const STATUS_STYLES: Record<

--- a/web-react/src/features/proof-editor/components/nodes/TacticNode.tsx
+++ b/web-react/src/features/proof-editor/components/nodes/TacticNode.tsx
@@ -10,9 +10,11 @@ import type { TacticType } from "@pie/protocol";
 import { TACTIC_REQUIREMENTS } from "@pie/protocol";
 import { applyTactic as triggerApplyTactic } from "../../utils/tactic-callback";
 
-// Derive tactic categories from TACTIC_REQUIREMENTS (protocol.ts)
+// Tactics whose variableName parameter is chosen from an existing goal context.
+// `intro` also has a variableName parameter, but it introduces a fresh name
+// through inline text input instead of connecting to a context handle.
 const CONTEXT_INPUT_TACTICS: TacticType[] = (Object.keys(TACTIC_REQUIREMENTS) as TacticType[])
-  .filter(t => TACTIC_REQUIREMENTS[t].variableName === true);
+  .filter(t => t !== "intro" && TACTIC_REQUIREMENTS[t].variableName === true);
 
 const PARAMETERLESS_TACTICS: TacticType[] = (Object.keys(TACTIC_REQUIREMENTS) as TacticType[])
   .filter(t => !TACTIC_REQUIREMENTS[t].variableName && !TACTIC_REQUIREMENTS[t].expression);

--- a/web-react/src/features/proof-editor/components/panels/DefinitionsPanel.tsx
+++ b/web-react/src/features/proof-editor/components/panels/DefinitionsPanel.tsx
@@ -34,7 +34,7 @@ export function DefinitionsPanel({
 
   if (collapsed) {
     return (
-      <div className="w-10 border-l bg-gray-50 flex flex-col items-center pt-2">
+      <div className="w-10 shrink-0 border-l bg-gray-50 flex flex-col items-center pt-2">
         <button
           onClick={onToggleCollapse}
           className="p-2 rounded hover:bg-gray-200"
@@ -49,7 +49,7 @@ export function DefinitionsPanel({
   }
 
   return (
-    <div className="w-64 border-l bg-gray-50 flex flex-col overflow-hidden">
+    <div className="w-64 shrink-0 border-l bg-gray-50 flex flex-col overflow-hidden">
       {/* Header */}
       <div className="flex items-center justify-between border-b bg-white p-3">
         <h2 className="font-semibold text-sm">Context</h2>

--- a/web-react/src/features/proof-editor/components/panels/DetailPanel.tsx
+++ b/web-react/src/features/proof-editor/components/panels/DetailPanel.tsx
@@ -18,7 +18,7 @@ export function DetailPanel() {
   // No selection - show placeholder
   if (!selectedNode) {
     return (
-      <div className="w-80 border-l bg-gray-50 p-4">
+      <div className="w-80 shrink-0 border-l bg-gray-50 p-4">
         <p className="text-sm text-gray-500">
           Click on a node to see details
         </p>
@@ -35,7 +35,7 @@ export function DetailPanel() {
     case 'lemma':
       // TODO: LemmaDetailPanel
       return (
-        <div className="w-80 border-l bg-gray-50 p-4">
+        <div className="w-80 shrink-0 border-l bg-gray-50 p-4">
           <p className="text-sm text-gray-500">
             Lemma details coming soon
           </p>

--- a/web-react/src/features/proof-editor/components/panels/GoalDetailPanel.tsx
+++ b/web-react/src/features/proof-editor/components/panels/GoalDetailPanel.tsx
@@ -66,15 +66,10 @@ export function GoalDetailPanel() {
   const descriptionSignature = useMemo(() => {
     if (!selectedNode || !sourceCode || !claimName) return null;
 
-    return JSON.stringify({
-      sourceCode,
-      claimName,
-      goalType: selectedNode.data.goalType,
-      context: selectedNode.data.context.map((entry) => ({
-        name: entry.name,
-        type: entry.type,
-      })),
-    });
+    const contextKey = selectedNode.data.context
+      .map((e) => `${e.name}:${e.type}`)
+      .join(",");
+    return `${claimName}\x00${selectedNode.data.goalType}\x00${contextKey}\x00${sourceCode}`;
   }, [selectedNode, sourceCode, claimName]);
 
   const descEntry =

--- a/web-react/src/features/proof-editor/components/panels/GoalDetailPanel.tsx
+++ b/web-react/src/features/proof-editor/components/panels/GoalDetailPanel.tsx
@@ -1,4 +1,4 @@
-import { useCallback, useEffect } from "react";
+import { useCallback, useEffect, useMemo } from "react";
 import { useProofStore, useUIStore } from "../../store";
 import { useHintStore } from "../../store/hint-store";
 import { useGoalDescriptionStore } from "../../store/goal-description-store";
@@ -25,6 +25,17 @@ function parseErrorMessage(raw: string): string {
   return raw;
 }
 
+function getErrorMessage(error: unknown): string {
+  if (error instanceof Error) return error.message;
+  if (typeof error === "string") return error;
+
+  try {
+    return JSON.stringify(error);
+  } catch {
+    return "Unknown error";
+  }
+}
+
 /**
  * GoalDetailPanel Component
  *
@@ -43,7 +54,7 @@ export function GoalDetailPanel() {
   const setLoading = useGoalDescriptionStore((s) => s.setLoading);
   const setDescription = useGoalDescriptionStore((s) => s.setDescription);
   const setError = useGoalDescriptionStore((s) => s.setError);
-  const descEntry = useGoalDescriptionStore((s) =>
+  const rawDescEntry = useGoalDescriptionStore((s) =>
     selectedNodeId ? s.descriptions.get(selectedNodeId) : undefined,
   );
 
@@ -52,19 +63,47 @@ export function GoalDetailPanel() {
     (n): n is GoalNode => n.id === selectedNodeId && n.type === "goal",
   );
 
+  const descriptionSignature = useMemo(() => {
+    if (!selectedNode || !sourceCode || !claimName) return null;
+
+    return JSON.stringify({
+      sourceCode,
+      claimName,
+      goalType: selectedNode.data.goalType,
+      context: selectedNode.data.context.map((entry) => ({
+        name: entry.name,
+        type: entry.type,
+      })),
+    });
+  }, [selectedNode, sourceCode, claimName]);
+
+  const descEntry =
+    rawDescEntry?.signature === descriptionSignature ? rawDescEntry : undefined;
+
   // ---------------------------------------------------------------------------
-  // Description fetching — uses the full session source code and the claim
-  // name being proved, so the LLM has full context.
+  // Description fetching uses the full source as background, then asks the LLM
+  // to describe the currently selected proof goal and its local context.
   // ---------------------------------------------------------------------------
   const fetchDescription = useCallback(
-    async (nodeId: string) => {
+    async (nodeId: string, goal: GoalNode["data"], signature: string) => {
       if (!apiKey || !sourceCode || !claimName) return;
-      setLoading(nodeId);
+      setLoading(nodeId, signature);
       try {
-        const text = await describeGoalBrowser(sourceCode, claimName, apiKey);
-        setDescription(nodeId, text);
+        const text = await describeGoalBrowser(
+          {
+            pieCode: sourceCode,
+            claimName,
+            goalType: goal.goalType,
+            context: goal.context.map((entry) => ({
+              name: entry.name,
+              type: entry.type,
+            })),
+          },
+          apiKey,
+        );
+        setDescription(nodeId, signature, text);
       } catch (e) {
-        setError(nodeId, e instanceof Error ? e.message : String(e));
+        setError(nodeId, signature, getErrorMessage(e));
       }
     },
     [apiKey, sourceCode, claimName, setLoading, setDescription, setError],
@@ -74,9 +113,10 @@ export function GoalDetailPanel() {
   useEffect(() => {
     if (!selectedNodeId || !selectedNode) return;
     if (!apiKey || !sourceCode || !claimName) return;
+    if (!descriptionSignature) return;
     // Only auto-fetch if we have no cached entry for this node yet
     if (!descEntry) {
-      fetchDescription(selectedNodeId);
+      fetchDescription(selectedNodeId, selectedNode.data, descriptionSignature);
     }
   }, [
     selectedNodeId,
@@ -84,6 +124,7 @@ export function GoalDetailPanel() {
     apiKey,
     sourceCode,
     claimName,
+    descriptionSignature,
     descEntry,
     fetchDescription,
   ]);
@@ -173,7 +214,11 @@ export function GoalDetailPanel() {
           </div>
           {apiKey && (
             <button
-              onClick={() => selectedNodeId && fetchDescription(selectedNodeId)}
+              onClick={() =>
+                selectedNodeId &&
+                descriptionSignature &&
+                fetchDescription(selectedNodeId, data, descriptionSignature)
+              }
               disabled={descEntry?.isLoading}
               title="Refresh description"
               className={cn(

--- a/web-react/src/features/proof-editor/components/panels/GoalDetailPanel.tsx
+++ b/web-react/src/features/proof-editor/components/panels/GoalDetailPanel.tsx
@@ -150,7 +150,7 @@ export function GoalDetailPanel() {
   };
 
   return (
-    <div className="w-80 border-l bg-white overflow-y-auto">
+    <div className="w-80 shrink-0 border-l bg-white overflow-y-auto">
       {/* Header */}
       <div className="flex items-center justify-between border-b p-4">
         <h2 className="font-semibold">Goal Details</h2>

--- a/web-react/src/features/proof-editor/components/panels/SourceCodePanel.tsx
+++ b/web-react/src/features/proof-editor/components/panels/SourceCodePanel.tsx
@@ -24,122 +24,119 @@ const SAMPLE_SOURCE = `; Define addition function
     (= Nat n n)))
 `;
 
-const PIE_LANGUAGE_GUARD = '__pieLanguageRegistered';
-const PIE_COMPLETION_GUARD = '__pieCompletionRegistered';
-const PIE_HOVER_GUARD = '__pieHoverRegistered';
+function once(monaco: Monaco, key: string, fn: () => void) {
+  const m = monaco as Monaco & Record<string, boolean>;
+  if (m[key]) return;
+  m[key] = true;
+  fn();
+}
 
 function registerPieLanguage(monaco: Monaco) {
-  const guarded = monaco as Monaco & Record<string, boolean>;
-  if (guarded[PIE_LANGUAGE_GUARD]) return;
-  guarded[PIE_LANGUAGE_GUARD] = true;
-
-  monaco.languages.register({ id: 'pie' });
-  monaco.languages.setMonarchTokensProvider('pie', {
-    tokenizer: {
-      root: [
-        [/;.*$/, 'comment'],
-        [/\d+/, 'number'],
-        [
-          /\b(claim|define|define-tactically|lambda|Pi|Sigma|the|then)\b/,
-          'keyword',
+  once(monaco, '__pieLanguageRegistered', () => {
+    monaco.languages.register({ id: 'pie' });
+    monaco.languages.setMonarchTokensProvider('pie', {
+      tokenizer: {
+        root: [
+          [/;.*$/, 'comment'],
+          [/\d+/, 'number'],
+          [
+            /\b(claim|define|define-tactically|lambda|Pi|Sigma|the|then)\b/,
+            'keyword',
+          ],
+          [
+            /\b(Nat|Atom|Trivial|Absurd|U|Pair|Either|List|Vec)\b|->|=/,
+            'type',
+          ],
+          [
+            /\b(zero|add1|same|sole|nil|cons|car|cdr|left|right|intro|exact|exists|apply|split-Pair|elim-Nat|elim-List|elim-Vec|elim-Either|elim-Equal|elim-Absurd)\b/,
+            'variable',
+          ],
+          [/[()[\]]/, 'delimiter'],
+          [/[^\s()[\]"]+/, 'identifier'],
         ],
-        [
-          /\b(Nat|Atom|Trivial|Absurd|U|Pair|Either|List|Vec)\b|->|=/,
-          'type',
-        ],
-        [
-          /\b(zero|add1|same|sole|nil|cons|car|cdr|left|right|intro|exact|exists|apply|split-Pair|elim-Nat|elim-List|elim-Vec|elim-Either|elim-Equal|elim-Absurd)\b/,
-          'variable',
-        ],
-        [/[()[\]]/, 'delimiter'],
-        [/[^\s()[\]"]+/, 'identifier'],
+      },
+    });
+    monaco.languages.setLanguageConfiguration('pie', {
+      comments: { lineComment: ';' },
+      brackets: [
+        ['(', ')'],
+        ['[', ']'],
       ],
-    },
-  });
-  monaco.languages.setLanguageConfiguration('pie', {
-    comments: { lineComment: ';' },
-    brackets: [
-      ['(', ')'],
-      ['[', ']'],
-    ],
-    autoClosingPairs: [
-      { open: '(', close: ')' },
-      { open: '[', close: ']' },
-      { open: '"', close: '"' },
-    ],
-    wordPattern: /[^\s()[\]"]+/g,
+      autoClosingPairs: [
+        { open: '(', close: ')' },
+        { open: '[', close: ']' },
+        { open: '"', close: '"' },
+      ],
+      wordPattern: /[^\s()[\]"]+/g,
+    });
   });
 }
 
 function registerPieCompletions(monaco: Monaco) {
-  const guarded = monaco as Monaco & Record<string, boolean>;
-  if (guarded[PIE_COMPLETION_GUARD]) return;
-  guarded[PIE_COMPLETION_GUARD] = true;
-
-  monaco.languages.registerCompletionItemProvider('pie', {
-    triggerCharacters: ['(', '-', '=', ':'],
-    async provideCompletionItems(model, position) {
-      const word = model.getWordUntilPosition(position);
-      const range = {
-        startLineNumber: position.lineNumber,
-        endLineNumber: position.lineNumber,
-        startColumn: word.startColumn,
-        endColumn: word.endColumn,
-      };
-
-      try {
-        const items = await diagnosticsWorker.getCompletions(
-          model.getValue(),
-          position.lineNumber,
-          position.column,
-        );
-        const kindMap = {
-          keyword: monaco.languages.CompletionItemKind.Keyword,
-          function: monaco.languages.CompletionItemKind.Function,
-          variable: monaco.languages.CompletionItemKind.Variable,
-          type: monaco.languages.CompletionItemKind.Class,
+  once(monaco, '__pieCompletionRegistered', () => {
+    monaco.languages.registerCompletionItemProvider('pie', {
+      triggerCharacters: ['(', '-', '=', ':'],
+      async provideCompletionItems(model, position) {
+        const word = model.getWordUntilPosition(position);
+        const range = {
+          startLineNumber: position.lineNumber,
+          endLineNumber: position.lineNumber,
+          startColumn: word.startColumn,
+          endColumn: word.endColumn,
         };
 
-        return {
-          suggestions: items.map((item) => ({
-            label: item.label,
-            kind: kindMap[item.kind],
-            detail: item.detail,
-            insertText: item.insertText ?? item.label,
-            insertTextRules: item.insertText
-              ? monaco.languages.CompletionItemInsertTextRule.InsertAsSnippet
-              : undefined,
-            range,
-          })),
-        };
-      } catch {
-        return { suggestions: [] };
-      }
-    },
+        try {
+          const items = await diagnosticsWorker.getCompletions(
+            model.getValue(),
+            position.lineNumber,
+            position.column,
+          );
+          const kindMap = {
+            keyword: monaco.languages.CompletionItemKind.Keyword,
+            function: monaco.languages.CompletionItemKind.Function,
+            variable: monaco.languages.CompletionItemKind.Variable,
+            type: monaco.languages.CompletionItemKind.Class,
+          };
+
+          return {
+            suggestions: items.map((item) => ({
+              label: item.label,
+              kind: kindMap[item.kind],
+              detail: item.detail,
+              insertText: item.insertText ?? item.label,
+              insertTextRules: item.insertText
+                ? monaco.languages.CompletionItemInsertTextRule.InsertAsSnippet
+                : undefined,
+              range,
+            })),
+          };
+        } catch {
+          return { suggestions: [] };
+        }
+      },
+    });
   });
 }
 
 function registerPieHover(monaco: Monaco) {
-  const guarded = monaco as Monaco & Record<string, boolean>;
-  if (guarded[PIE_HOVER_GUARD]) return;
-  guarded[PIE_HOVER_GUARD] = true;
+  once(monaco, '__pieHoverRegistered', () => {
+    monaco.languages.registerHoverProvider('pie', {
+      async provideHover(model, position) {
+        const hover = await diagnosticsWorker.getHoverInfo(
+          model.getValue(),
+          position.lineNumber,
+          position.column,
+        );
+        if (!hover) return null;
 
-  monaco.languages.registerHoverProvider('pie', {
-    async provideHover(model, position) {
-      const hover = await diagnosticsWorker.getHoverInfo(
-        model.getValue(),
-        position.lineNumber,
-        position.column,
-      );
-      if (!hover) return null;
-
-      return {
-        contents: [
-          { value: `**${hover.documentation ?? 'Pie symbol'}**` },
-          { value: `\`\`\`pie\n${hover.type}\n\`\`\`` },
-        ],
-      };
-    },
+        return {
+          contents: [
+            { value: `**${hover.documentation ?? 'Pie symbol'}**` },
+            { value: `\`\`\`pie\n${hover.type}\n\`\`\`` },
+          ],
+        };
+      },
+    });
   });
 }
 
@@ -325,8 +322,8 @@ export function SourceCodePanel() {
                     {liveDiagnostics.length} source problem{liveDiagnostics.length > 1 ? 's' : ''}
                   </p>
                   <ul className="space-y-1 text-xs text-destructive">
-                    {liveDiagnostics.slice(0, 4).map((diagnostic, index) => (
-                      <li key={index}>
+                    {liveDiagnostics.slice(0, 4).map((diagnostic) => (
+                      <li key={`${diagnostic.range.startLine}:${diagnostic.range.startColumn}:${diagnostic.message}`}>
                         <span className="font-mono">
                           {diagnostic.range.startLine}:{diagnostic.range.startColumn}
                         </span>{' '}

--- a/web-react/src/features/proof-editor/components/panels/SourceCodePanel.tsx
+++ b/web-react/src/features/proof-editor/components/panels/SourceCodePanel.tsx
@@ -1,7 +1,10 @@
-import { useState, useCallback, useEffect } from 'react';
+import { useState, useCallback, useEffect, useRef } from 'react';
+import Editor, { type BeforeMount, type Monaco, type OnMount } from '@monaco-editor/react';
 import { useProofSession } from '../../hooks/useProofSession';
 import { useGeneratedProofScript } from '../../store';
 import { useExampleStore } from '../../store/example-store';
+import { diagnosticsWorker } from '@/shared/lib/worker-client';
+import type { Diagnostic as WorkerDiagnostic } from '@/workers/diagnostics-worker';
 
 /**
  * Sample Pie source code for demonstration.
@@ -21,6 +24,125 @@ const SAMPLE_SOURCE = `; Define addition function
     (= Nat n n)))
 `;
 
+const PIE_LANGUAGE_GUARD = '__pieLanguageRegistered';
+const PIE_COMPLETION_GUARD = '__pieCompletionRegistered';
+const PIE_HOVER_GUARD = '__pieHoverRegistered';
+
+function registerPieLanguage(monaco: Monaco) {
+  const guarded = monaco as Monaco & Record<string, boolean>;
+  if (guarded[PIE_LANGUAGE_GUARD]) return;
+  guarded[PIE_LANGUAGE_GUARD] = true;
+
+  monaco.languages.register({ id: 'pie' });
+  monaco.languages.setMonarchTokensProvider('pie', {
+    tokenizer: {
+      root: [
+        [/;.*$/, 'comment'],
+        [/\d+/, 'number'],
+        [
+          /\b(claim|define|define-tactically|lambda|Pi|Sigma|the|then)\b/,
+          'keyword',
+        ],
+        [
+          /\b(Nat|Atom|Trivial|Absurd|U|Pair|Either|List|Vec)\b|->|=/,
+          'type',
+        ],
+        [
+          /\b(zero|add1|same|sole|nil|cons|car|cdr|left|right|intro|exact|exists|apply|split-Pair|elim-Nat|elim-List|elim-Vec|elim-Either|elim-Equal|elim-Absurd)\b/,
+          'variable',
+        ],
+        [/[()[\]]/, 'delimiter'],
+        [/[^\s()[\]"]+/, 'identifier'],
+      ],
+    },
+  });
+  monaco.languages.setLanguageConfiguration('pie', {
+    comments: { lineComment: ';' },
+    brackets: [
+      ['(', ')'],
+      ['[', ']'],
+    ],
+    autoClosingPairs: [
+      { open: '(', close: ')' },
+      { open: '[', close: ']' },
+      { open: '"', close: '"' },
+    ],
+    wordPattern: /[^\s()[\]"]+/g,
+  });
+}
+
+function registerPieCompletions(monaco: Monaco) {
+  const guarded = monaco as Monaco & Record<string, boolean>;
+  if (guarded[PIE_COMPLETION_GUARD]) return;
+  guarded[PIE_COMPLETION_GUARD] = true;
+
+  monaco.languages.registerCompletionItemProvider('pie', {
+    triggerCharacters: ['(', '-', '=', ':'],
+    async provideCompletionItems(model, position) {
+      const word = model.getWordUntilPosition(position);
+      const range = {
+        startLineNumber: position.lineNumber,
+        endLineNumber: position.lineNumber,
+        startColumn: word.startColumn,
+        endColumn: word.endColumn,
+      };
+
+      try {
+        const items = await diagnosticsWorker.getCompletions(
+          model.getValue(),
+          position.lineNumber,
+          position.column,
+        );
+        const kindMap = {
+          keyword: monaco.languages.CompletionItemKind.Keyword,
+          function: monaco.languages.CompletionItemKind.Function,
+          variable: monaco.languages.CompletionItemKind.Variable,
+          type: monaco.languages.CompletionItemKind.Class,
+        };
+
+        return {
+          suggestions: items.map((item) => ({
+            label: item.label,
+            kind: kindMap[item.kind],
+            detail: item.detail,
+            insertText: item.insertText ?? item.label,
+            insertTextRules: item.insertText
+              ? monaco.languages.CompletionItemInsertTextRule.InsertAsSnippet
+              : undefined,
+            range,
+          })),
+        };
+      } catch {
+        return { suggestions: [] };
+      }
+    },
+  });
+}
+
+function registerPieHover(monaco: Monaco) {
+  const guarded = monaco as Monaco & Record<string, boolean>;
+  if (guarded[PIE_HOVER_GUARD]) return;
+  guarded[PIE_HOVER_GUARD] = true;
+
+  monaco.languages.registerHoverProvider('pie', {
+    async provideHover(model, position) {
+      const hover = await diagnosticsWorker.getHoverInfo(
+        model.getValue(),
+        position.lineNumber,
+        position.column,
+      );
+      if (!hover) return null;
+
+      return {
+        contents: [
+          { value: `**${hover.documentation ?? 'Pie symbol'}**` },
+          { value: `\`\`\`pie\n${hover.type}\n\`\`\`` },
+        ],
+      };
+    },
+  });
+}
+
 /**
  * SourceCodePanel - Collapsible panel for entering Pie source code and starting proofs.
  *
@@ -36,6 +158,9 @@ export function SourceCodePanel() {
   const [isExpanded, setIsExpanded] = useState(true);
   const [sourceCode, setSourceCode] = useState(SAMPLE_SOURCE);
   const [claimName, setClaimName] = useState('reflexivity');
+  const [liveDiagnostics, setLiveDiagnostics] = useState<WorkerDiagnostic[]>([]);
+  const editorRef = useRef<Parameters<OnMount>[0] | null>(null);
+  const monacoRef = useRef<Parameters<OnMount>[1] | null>(null);
 
   // Get example from store
   const exampleSource = useExampleStore((s) => s.exampleSource);
@@ -66,6 +191,59 @@ export function SourceCodePanel() {
 
   // Get the generated proof script from the store
   const generatedScript = useGeneratedProofScript();
+
+  const handleBeforeMount: BeforeMount = useCallback((monaco) => {
+    registerPieLanguage(monaco);
+    registerPieCompletions(monaco);
+    registerPieHover(monaco);
+  }, []);
+
+  const handleEditorMount: OnMount = useCallback((editor, monaco) => {
+    editorRef.current = editor;
+    monacoRef.current = monaco;
+  }, []);
+
+  useEffect(() => {
+    let isCancelled = false;
+    const timer = window.setTimeout(async () => {
+      const editor = editorRef.current;
+      const monaco = monacoRef.current;
+      const model = editor?.getModel();
+      if (!editor || !monaco || !model) return;
+
+      try {
+        const result = await diagnosticsWorker.checkSource(sourceCode);
+        if (isCancelled) return;
+
+        monaco.editor.setModelMarkers(
+          model,
+          'pie',
+          result.diagnostics.map((diagnostic) => ({
+            severity:
+              diagnostic.severity === 'error'
+                ? monaco.MarkerSeverity.Error
+                : monaco.MarkerSeverity.Warning,
+            message: diagnostic.message,
+            startLineNumber: diagnostic.range.startLine,
+            startColumn: diagnostic.range.startColumn,
+            endLineNumber: diagnostic.range.endLine,
+            endColumn: diagnostic.range.endColumn,
+          })),
+        );
+        setLiveDiagnostics(result.diagnostics);
+      } catch {
+        if (!isCancelled) {
+          monaco.editor.setModelMarkers(model, 'pie', []);
+          setLiveDiagnostics([]);
+        }
+      }
+    }, 350);
+
+    return () => {
+      isCancelled = true;
+      window.clearTimeout(timer);
+    };
+  }, [sourceCode]);
 
   const handleStartProof = useCallback(async () => {
     if (!sourceCode.trim() || !claimName.trim()) {
@@ -118,13 +296,46 @@ export function SourceCodePanel() {
               <label className="mb-1 block text-sm font-medium text-muted-foreground">
                 Pie Source Code
               </label>
-              <textarea
-                className="h-32 w-full rounded-md border bg-background px-3 py-2 font-mono text-sm focus:outline-none focus:ring-2 focus:ring-primary"
-                placeholder="Enter Pie source code (claims, definitions)..."
-                value={sourceCode}
-                onChange={(e) => setSourceCode(e.target.value)}
-                disabled={isLoading}
-              />
+              <div className="overflow-hidden rounded-md border">
+                <Editor
+                  height="160px"
+                  language="pie"
+                  value={sourceCode}
+                  beforeMount={handleBeforeMount}
+                  onMount={handleEditorMount}
+                  onChange={(value) => setSourceCode(value ?? '')}
+                  options={{
+                    minimap: { enabled: false },
+                    fontSize: 13,
+                    lineNumbers: 'on',
+                    scrollBeyondLastLine: false,
+                    wordWrap: 'on',
+                    automaticLayout: true,
+                    tabSize: 2,
+                    insertSpaces: true,
+                    readOnly: isLoading,
+                    quickSuggestions: { other: true, comments: false, strings: false },
+                    suggestOnTriggerCharacters: true,
+                  }}
+                />
+              </div>
+              {liveDiagnostics.length > 0 && (
+                <div className="mt-2 max-h-24 overflow-auto rounded-md border border-destructive/40 bg-destructive/10 p-2">
+                  <p className="mb-1 text-xs font-semibold text-destructive">
+                    {liveDiagnostics.length} source problem{liveDiagnostics.length > 1 ? 's' : ''}
+                  </p>
+                  <ul className="space-y-1 text-xs text-destructive">
+                    {liveDiagnostics.slice(0, 4).map((diagnostic, index) => (
+                      <li key={index}>
+                        <span className="font-mono">
+                          {diagnostic.range.startLine}:{diagnostic.range.startColumn}
+                        </span>{' '}
+                        {diagnostic.message}
+                      </li>
+                    ))}
+                  </ul>
+                </div>
+              )}
             </div>
 
             {/* Claim name and button */}

--- a/web-react/src/features/proof-editor/components/panels/TacticDetailPanel.tsx
+++ b/web-react/src/features/proof-editor/components/panels/TacticDetailPanel.tsx
@@ -35,7 +35,7 @@ export function TacticDetailPanel() {
   );
 
   return (
-    <div className="w-80 border-l bg-white overflow-y-auto">
+    <div className="w-80 shrink-0 border-l bg-white overflow-y-auto">
       {/* Header */}
       <div className="flex items-center justify-between border-b p-4">
         <h2 className="font-semibold">Tactic Details</h2>

--- a/web-react/src/features/proof-editor/components/panels/TacticPalette.tsx
+++ b/web-react/src/features/proof-editor/components/panels/TacticPalette.tsx
@@ -33,7 +33,7 @@ export function TacticPalette() {
   };
 
   return (
-    <div className="w-56 border-r bg-gray-50 overflow-y-auto">
+    <div className="w-56 shrink-0 border-r bg-gray-50 overflow-y-auto">
       {/* Header */}
       <div className="border-b bg-white p-3">
         <h2 className="font-semibold text-sm">Tactics</h2>

--- a/web-react/src/features/proof-editor/hooks/useAutoLayout.ts
+++ b/web-react/src/features/proof-editor/hooks/useAutoLayout.ts
@@ -1,0 +1,76 @@
+import { useEffect, useRef } from "react";
+import { useNodesInitialized, useReactFlow } from "@xyflow/react";
+import { useProofStore } from "../store";
+import { computeTreeLayout } from "../utils/convert-proof-tree";
+import type { ProofTree } from "@pie/protocol";
+
+/**
+ * useAutoLayout
+ *
+ * Runs a second layout pass after React Flow has measured all proof nodes.
+ * The first pass (in convertProofTreeToReactFlow) places nodes using fallback
+ * size constants.  This hook fires once those nodes are rendered and replaces
+ * every position with one computed from the actual measured width/height,
+ * so the tree stays properly spaced regardless of content length or context
+ * variable count.
+ *
+ * It re-runs automatically after each syncFromWorker call (tactic apply or
+ * retract), because proofTreeData gets a new object reference each time.
+ *
+ * Nodes the user has manually dragged are left in place.
+ */
+export function useAutoLayout() {
+  const nodesInitialized = useNodesInitialized();
+  const { getNodes } = useReactFlow();
+  const proofTreeData = useProofStore((s) => s.proofTreeData);
+  const setLayoutPositions = useProofStore((s) => s.setLayoutPositions);
+
+  // Track which tree we last laid out so we don't repeat work
+  const lastTree = useRef<ProofTree | null>(null);
+
+  useEffect(() => {
+    if (!nodesInitialized || !proofTreeData) return;
+    if (proofTreeData === lastTree.current) return;
+
+    const nodes = getNodes();
+
+    // Collect measured sizes for every proof node (goal + tactic).
+    // Ghost and lemma nodes are not part of the tree layout, so we skip them.
+    const measuredSizes = new Map<string, { width: number; height: number }>();
+    for (const node of nodes) {
+      if (node.type !== "goal" && node.type !== "tactic") continue;
+      if (node.measured?.width != null && node.measured?.height != null) {
+        measuredSizes.set(node.id, {
+          width: node.measured.width,
+          height: node.measured.height,
+        });
+      }
+    }
+
+    // Wait until every goal and tactic node has been measured
+    const proofNodes = nodes.filter(
+      (n) => n.type === "goal" || n.type === "tactic",
+    );
+    if (proofNodes.some((n) => !measuredSizes.has(n.id))) return;
+
+    // Compute positions using actual node sizes
+    const newPositions = computeTreeLayout(proofTreeData.root, measuredSizes);
+
+    // Skip nodes the user has manually moved — read directly from store to
+    // avoid adding manualPositions as a reactive dependency (which would cause
+    // this effect to re-run on every drag).
+    const manualPositions = useProofStore.getState().manualPositions;
+    const toApply = new Map<string, { x: number; y: number }>();
+    for (const [id, pos] of newPositions) {
+      if (!manualPositions.has(id)) {
+        toApply.set(id, pos);
+      }
+    }
+
+    if (toApply.size > 0) {
+      setLayoutPositions(toApply);
+    }
+
+    lastTree.current = proofTreeData;
+  }, [nodesInitialized, proofTreeData, getNodes, setLayoutPositions]);
+}

--- a/web-react/src/features/proof-editor/hooks/useHintSystem.ts
+++ b/web-react/src/features/proof-editor/hooks/useHintSystem.ts
@@ -179,9 +179,9 @@ export function useHintSystem() {
     // Determine initial status based on whether we have all parameters (derived from protocol)
     const tacticType = hint.tacticType!;
     const reqs = TACTIC_REQUIREMENTS[tacticType as TacticType];
-    const needsVariable = reqs?.variableName === true;
+    const needsVariable = reqs?.variableName === true || tacticType === 'intro';
     const needsExpression = reqs?.expression === true;
-    const isParameterless = !reqs?.variableName && !reqs?.expression;
+    const isParameterless = tacticType !== 'intro' && !reqs?.variableName && !reqs?.expression;
 
     let initialStatus: 'incomplete' | 'ready' = 'incomplete';
     if (isParameterless) {

--- a/web-react/src/features/proof-editor/hooks/useHintSystem.ts
+++ b/web-react/src/features/proof-editor/hooks/useHintSystem.ts
@@ -179,9 +179,9 @@ export function useHintSystem() {
     // Determine initial status based on whether we have all parameters (derived from protocol)
     const tacticType = hint.tacticType!;
     const reqs = TACTIC_REQUIREMENTS[tacticType as TacticType];
-    const needsVariable = reqs?.variableName === true || tacticType === 'intro';
+    const needsVariable = reqs?.variableName === true;
     const needsExpression = reqs?.expression === true;
-    const isParameterless = tacticType !== 'intro' && !reqs?.variableName && !reqs?.expression;
+    const isParameterless = !reqs?.variableName && !reqs?.expression;
 
     let initialStatus: 'incomplete' | 'ready' = 'incomplete';
     if (isParameterless) {

--- a/web-react/src/features/proof-editor/hooks/useProofSession.ts
+++ b/web-react/src/features/proof-editor/hooks/useProofSession.ts
@@ -1,6 +1,8 @@
 import { useState, useCallback } from "react";
 import { proofWorker } from "@/shared/lib/worker-client";
 import { useProofStore } from "../store";
+import { useHintStore } from "../store/hint-store";
+import { useGoalDescriptionStore } from "../store/goal-description-store";
 import { useMetadataStore } from "../store/metadata-store";
 import type {
   TacticParams,
@@ -35,6 +37,8 @@ export function useProofSession() {
   const syncFromWorker = useProofStore((s) => s.syncFromWorker);
   const saveSnapshot = useProofStore((s) => s.saveSnapshot);
   const sessionId = useProofStore((s) => s.sessionId);
+  const clearHints = useHintStore((s) => s.clearAllHints);
+  const clearGoalDescriptions = useGoalDescriptionStore((s) => s.clearAll);
 
   /**
    * Start a new proof session.
@@ -54,6 +58,9 @@ export function useProofSession() {
       try {
         const result = await proofWorker.startSession(sourceCode, claimName);
 
+        clearHints();
+        clearGoalDescriptions();
+
         // Sync the proof tree to the store (include claimName for script generation)
         syncFromWorker(result.proofTree, result.sessionId, claimName);
         saveSnapshot();
@@ -64,8 +71,6 @@ export function useProofSession() {
         setGlobalContext(result.globalContext);
         setMetadataClaimName(claimName); // Store claim name in metadata store
         setSourceCode(sourceCode); // Store source code for goal descriptions
-
-        setMetadataClaimName(claimName); // Store claim name in metadata store
 
         return result;
       } catch (e) {
@@ -82,6 +87,8 @@ export function useProofSession() {
       setGlobalContext,
       setMetadataClaimName,
       setSourceCode,
+      clearHints,
+      clearGoalDescriptions,
     ],
   );
 
@@ -149,11 +156,19 @@ export function useProofSession() {
       setClaimType(null);
       setGlobalContext({ definitions: [], theorems: [] });
       setMetadataClaimName(null);
+      clearHints();
+      clearGoalDescriptions();
       setError(null);
     } catch (e) {
       console.error("Failed to close session:", e);
     }
-  }, [sessionId, setGlobalContext, setMetadataClaimName]);
+  }, [
+    sessionId,
+    setGlobalContext,
+    setMetadataClaimName,
+    clearHints,
+    clearGoalDescriptions,
+  ]);
 
   /**
    * Clear any error state.

--- a/web-react/src/features/proof-editor/lib/describeGoalBrowser.test.ts
+++ b/web-react/src/features/proof-editor/lib/describeGoalBrowser.test.ts
@@ -1,0 +1,34 @@
+import { describe, expect, it } from "vitest";
+import { buildGoalOverviewPrompt } from "./describeGoalBrowser";
+
+describe("buildGoalOverviewPrompt", () => {
+  it("includes the selected goal type and local context", () => {
+    const prompt = buildGoalOverviewPrompt({
+      pieCode: "(claim plus-zero (Pi ((n Nat)) (= Nat n n)))",
+      claimName: "plus-zero",
+      goalType: "(= Nat (plus k 0) k)",
+      context: [
+        { name: "k", type: "Nat" },
+        { name: "ih", type: "(= Nat (plus k 0) k)" },
+      ],
+    });
+
+    expect(prompt).toContain("Claim being proved:** `plus-zero`");
+    expect(prompt).toContain("Selected proof goal type");
+    expect(prompt).toContain("(= Nat (plus k 0) k)");
+    expect(prompt).toContain("- k : Nat");
+    expect(prompt).toContain("- ih : (= Nat (plus k 0) k)");
+    expect(prompt).toContain("Focuses on the selected proof goal type");
+  });
+
+  it("marks an empty local context explicitly", () => {
+    const prompt = buildGoalOverviewPrompt({
+      pieCode: "(claim id (Pi ((A U)) (-> A A)))",
+      claimName: "id",
+      goalType: "(Pi ((A U)) (-> A A))",
+      context: [],
+    });
+
+    expect(prompt).toContain("No local context bindings.");
+  });
+});

--- a/web-react/src/features/proof-editor/lib/describeGoalBrowser.ts
+++ b/web-react/src/features/proof-editor/lib/describeGoalBrowser.ts
@@ -13,6 +13,18 @@ interface FewShotExample {
   description: string;
 }
 
+export interface GoalOverviewContextEntry {
+  name: string;
+  type: string;
+}
+
+export interface GoalOverviewRequest {
+  pieCode: string;
+  claimName: string;
+  goalType: string;
+  context: GoalOverviewContextEntry[];
+}
+
 const FEW_SHOT_EXAMPLES: FewShotExample[] = [
   {
     pieCode: `
@@ -157,7 +169,15 @@ function escapeRegExp(s: string): string {
   return s.replace(/[.*+?^${}()|[\]\\]/g, "\\$&");
 }
 
-function buildPrompt(pieCode: string, goalName: string): string {
+function formatContext(context: GoalOverviewContextEntry[]): string {
+  if (context.length === 0) {
+    return "No local context bindings.";
+  }
+
+  return context.map((entry) => `- ${entry.name} : ${entry.type}`).join("\n");
+}
+
+export function buildGoalOverviewPrompt(request: GoalOverviewRequest): string {
   const fewShotSection = FEW_SHOT_EXAMPLES.map(
     (ex, i) =>
       `### Example ${i + 1}\n` +
@@ -169,10 +189,12 @@ function buildPrompt(pieCode: string, goalName: string): string {
   return (
     `You are an expert in dependently-typed programming languages, specifically Pie ` +
     `(the language from "The Little Typer" by Daniel P. Friedman and David Thrane Christiansen). ` +
-    `Your task is to read a snippet of Pie code and write a clear, accurate natural-language description ` +
-    `of what a specific named goal (claim) means and asserts.\n\n` +
+    `Your task is to read a snippet of Pie code and write a clear, accurate natural-language overview ` +
+    `of the selected proof goal inside one named claim.\n\n` +
     `A good description:\n` +
-    `- Explains what the type of the goal asserts in plain English\n` +
+    `- Focuses on the selected proof goal type, not only the top-level claim\n` +
+    `- Explains what the current goal asserts in plain English\n` +
+    `- Uses the local proof context to explain what assumptions or variables are available\n` +
     `- Mentions key type-theoretic concepts (dependent types, induction, equality, etc.) where relevant\n` +
     `- Is precise but accessible to someone learning type theory\n` +
     `- Does NOT include code examples or Pie syntax in the reply\n` +
@@ -182,9 +204,11 @@ function buildPrompt(pieCode: string, goalName: string): string {
     fewShotSection +
     `\n\n---\n\n` +
     `## Your task\n\n` +
-    `**Pie code:**\n\`\`\`\n${pieCode}\n\`\`\`\n` +
-    `**Goal name:** \`${goalName}\`\n` +
-    `**Description:**`
+    `**Pie code for context:**\n\`\`\`\n${request.pieCode}\n\`\`\`\n` +
+    `**Claim being proved:** \`${request.claimName}\`\n` +
+    `**Selected proof goal type:**\n\`\`\`\n${request.goalType}\n\`\`\`\n` +
+    `**Local proof context:**\n${formatContext(request.context)}\n\n` +
+    `**Description of the selected proof goal:**`
   );
 }
 
@@ -195,26 +219,24 @@ function buildPrompt(pieCode: string, goalName: string): string {
 /**
  * Browser-compatible version of describeGoal.
  *
- * Queries Google Gemini to produce a natural-language description of a named
- * claim found inside a snippet of Pie code.
+ * Queries Google Gemini to produce a natural-language description of the
+ * currently selected proof goal.
  *
- * @param pieCode  - Pie source code containing at least the named claim.
- * @param goalName - The name of the `claim` to describe.
+ * @param request  - Pie source code, current claim, and selected goal details.
  * @param apiKey   - Google Gemini API key (from the user's settings).
  * @returns A promise resolving to the natural-language description.
  */
 export async function describeGoalBrowser(
-  pieCode: string,
-  goalName: string,
+  request: GoalOverviewRequest,
   apiKey: string,
 ): Promise<string> {
   // Validate that a claim with the given name exists in the code.
   const claimPattern = new RegExp(
-    `\\(\\s*claim\\s+${escapeRegExp(goalName)}\\s`,
+    `\\(\\s*claim\\s+${escapeRegExp(request.claimName)}\\s`,
   );
-  if (!claimPattern.test(pieCode)) {
+  if (!claimPattern.test(request.pieCode)) {
     throw new Error(
-      `No claim named '${goalName}' found in the provided Pie code.`,
+      `No claim named '${request.claimName}' found in the provided Pie code.`,
     );
   }
 
@@ -223,7 +245,7 @@ export async function describeGoalBrowser(
   // eslint-disable-next-line @typescript-eslint/no-explicit-any
   const result = await (genAI as any).models.generateContent({
     model: "gemini-2.5-flash",
-    contents: buildPrompt(pieCode, goalName),
+    contents: buildGoalOverviewPrompt(request),
   });
 
   if (!result.text) {

--- a/web-react/src/features/proof-editor/store/__tests__/goal-description-store.test.ts
+++ b/web-react/src/features/proof-editor/store/__tests__/goal-description-store.test.ts
@@ -1,0 +1,35 @@
+import { beforeEach, describe, expect, it } from "vitest";
+import { useGoalDescriptionStore } from "../goal-description-store";
+
+describe("goal-description-store", () => {
+  beforeEach(() => {
+    useGoalDescriptionStore.getState().clearAll();
+  });
+
+  it("stores the description signature with generated text", () => {
+    const store = useGoalDescriptionStore.getState();
+
+    store.setDescription("g0", "claim-a:goal-a", "First description");
+
+    expect(useGoalDescriptionStore.getState().getEntry("g0")).toEqual({
+      signature: "claim-a:goal-a",
+      text: "First description",
+      isLoading: false,
+      error: null,
+    });
+  });
+
+  it("replaces stale entries for the same node id with the latest signature", () => {
+    const store = useGoalDescriptionStore.getState();
+
+    store.setDescription("g0", "claim-a:goal-a", "First description");
+    store.setLoading("g0", "claim-b:goal-b");
+
+    expect(useGoalDescriptionStore.getState().getEntry("g0")).toEqual({
+      signature: "claim-b:goal-b",
+      text: null,
+      isLoading: true,
+      error: null,
+    });
+  });
+});

--- a/web-react/src/features/proof-editor/store/goal-description-store.ts
+++ b/web-react/src/features/proof-editor/store/goal-description-store.ts
@@ -6,6 +6,7 @@ import { subscribeWithSelector } from "zustand/middleware";
 // ---------------------------------------------------------------------------
 
 export interface GoalDescriptionEntry {
+  signature: string;
   text: string | null;
   isLoading: boolean;
   error: string | null;
@@ -18,11 +19,11 @@ export interface GoalDescriptionState {
 
 export interface GoalDescriptionActions {
   /** Mark a goal as loading (clears previous error). */
-  setLoading: (nodeId: string) => void;
+  setLoading: (nodeId: string, signature: string) => void;
   /** Store a successfully generated description. */
-  setDescription: (nodeId: string, text: string) => void;
+  setDescription: (nodeId: string, signature: string, text: string) => void;
   /** Store an error for a goal. */
-  setError: (nodeId: string, error: string) => void;
+  setError: (nodeId: string, signature: string, error: string) => void;
   /** Remove all cached entries (e.g. when a new proof session starts). */
   clearAll: () => void;
   /** Get the current entry for a goal, or undefined if not yet fetched. */
@@ -40,26 +41,26 @@ export const useGoalDescriptionStore = create<GoalDescriptionStore>()(
   subscribeWithSelector((set, get) => ({
     descriptions: new Map(),
 
-    setLoading: (nodeId) => {
+    setLoading: (nodeId, signature) => {
       set((state) => {
         const next = new Map(state.descriptions);
-        next.set(nodeId, { text: null, isLoading: true, error: null });
+        next.set(nodeId, { signature, text: null, isLoading: true, error: null });
         return { descriptions: next };
       });
     },
 
-    setDescription: (nodeId, text) => {
+    setDescription: (nodeId, signature, text) => {
       set((state) => {
         const next = new Map(state.descriptions);
-        next.set(nodeId, { text, isLoading: false, error: null });
+        next.set(nodeId, { signature, text, isLoading: false, error: null });
         return { descriptions: next };
       });
     },
 
-    setError: (nodeId, error) => {
+    setError: (nodeId, signature, error) => {
       set((state) => {
         const next = new Map(state.descriptions);
-        next.set(nodeId, { text: null, isLoading: false, error });
+        next.set(nodeId, { signature, text: null, isLoading: false, error });
         return { descriptions: next };
       });
     },

--- a/web-react/src/features/proof-editor/store/proof-store.ts
+++ b/web-react/src/features/proof-editor/store/proof-store.ts
@@ -514,6 +514,17 @@ export const useProofStore = create<ProofStore>()(
         });
       },
 
+      setLayoutPositions: (positions: Map<string, { x: number; y: number }>) => {
+        set((state) => {
+          for (const node of state.nodes) {
+            const pos = positions.get(node.id);
+            if (pos) {
+              node.position = { ...pos };
+            }
+          }
+        });
+      },
+
       // ================================================
       // Branch Collapse Management
       // ================================================

--- a/web-react/src/features/proof-editor/store/types.ts
+++ b/web-react/src/features/proof-editor/store/types.ts
@@ -219,6 +219,8 @@ export interface ProofActions {
   // Position management
   setManualPosition: (nodeId: string, position: { x: number; y: number }) => void;
   clearManualPositions: () => void;
+  // Apply auto-layout positions without recording them as manual overrides
+  setLayoutPositions: (positions: Map<string, { x: number; y: number }>) => void;
 
   // Branch collapse management
   toggleBranchCollapse: (goalId: string) => void;

--- a/web-react/src/features/proof-editor/utils/convert-proof-tree.ts
+++ b/web-react/src/features/proof-editor/utils/convert-proof-tree.ts
@@ -15,10 +15,18 @@ import type {
 import { nanoid } from "nanoid";
 
 // Layout constants
-const NODE_WIDTH = 200;
-const NODE_HEIGHT = 120;
-const HORIZONTAL_SPACING = 50;
-const VERTICAL_SPACING = 150;
+// NODE_WIDTH/HEIGHT are estimates used for spacing calculations.
+// Goals can be 200–320px wide (wider when displaying longer types or context vars),
+// and 120–220px tall depending on how many context entries they show.
+// Using conservative over-estimates prevents sibling overlap at the cost of
+// slightly more whitespace.
+const NODE_WIDTH = 280;          // goal node width estimate
+const NODE_HEIGHT = 175;         // goal node height estimate (includes ~2 context vars)
+const TACTIC_NODE_WIDTH = 200;   // tactic node width estimate
+const TACTIC_NODE_HEIGHT = 80;   // tactic node height estimate
+const HORIZONTAL_SPACING = 80;   // gap between sibling subtrees
+const GOAL_TO_TACTIC_GAP = 30;   // gap from goal bottom to tactic top
+const TACTIC_TO_GOAL_GAP = 40;   // gap from tactic bottom to child goal tops
 
 interface ConversionResult {
   nodes: ProofNode[];
@@ -117,12 +125,11 @@ function assignPositions(
 
   if (node.children.length === 0) return;
 
-  // Position children below, with tactic node in between
-  const tacticY = y + NODE_HEIGHT + VERTICAL_SPACING / 2;
-  const childrenY = y + NODE_HEIGHT + VERTICAL_SPACING;
+  // Tactic sits below the goal with GOAL_TO_TACTIC_GAP clearance.
+  // Children sit below the tactic with TACTIC_TO_GOAL_GAP clearance.
+  const tacticY = y + NODE_HEIGHT + GOAL_TO_TACTIC_GAP;
+  const childrenY = tacticY + TACTIC_NODE_HEIGHT + TACTIC_TO_GOAL_GAP;
 
-  // Calculate starting x for children
-  let childX = x;
   const totalChildrenWidth =
     node.children.reduce(
       (sum, child) => sum + (widths.get(child.goal.id) || NODE_WIDTH),
@@ -130,13 +137,14 @@ function assignPositions(
     ) +
     (node.children.length - 1) * HORIZONTAL_SPACING;
 
-  // Center children under parent
-  childX = x + (nodeWidth - totalChildrenWidth) / 2;
+  // Center children span under the allocated space
+  let childX = x + (nodeWidth - totalChildrenWidth) / 2;
 
-  // Store tactic position (centered between this node and children)
+  // Center tactic over the children span (independent of goal width)
   if (node.appliedTactic) {
     const tacticId = `tactic-for-${node.goal.id}`;
-    positions.set(tacticId, { x: nodeX, y: tacticY });
+    const tacticX = x + nodeWidth / 2 - TACTIC_NODE_WIDTH / 2;
+    positions.set(tacticId, { x: tacticX, y: tacticY });
   }
 
   // Position each child
@@ -196,8 +204,8 @@ function traverseTree(
   if (node.appliedTactic && node.children.length > 0) {
     const tacticId = `tactic-for-${node.goal.id}`;
     const tacticPosition = positions.get(tacticId) || {
-      x: position.x,
-      y: position.y + NODE_HEIGHT + VERTICAL_SPACING / 2,
+      x: position.x + (NODE_WIDTH - TACTIC_NODE_WIDTH) / 2,
+      y: position.y + NODE_HEIGHT + GOAL_TO_TACTIC_GAP,
     };
 
     const tacticNode: TacticNode = {
@@ -220,6 +228,8 @@ function traverseTree(
       id: `edge-${nanoid(8)}`,
       source: node.goal.id,
       target: tacticId,
+      sourceHandle: "goal-output",
+      targetHandle: "goal-input",
       data: { kind: "goal-to-tactic" },
     });
 
@@ -229,6 +239,8 @@ function traverseTree(
         id: `edge-${nanoid(8)}`,
         source: tacticId,
         target: child.goal.id,
+        sourceHandle: "tactic-output",
+        targetHandle: "goal-input",
         data: { kind: "tactic-to-goal", outputIndex: index },
       });
     });
@@ -238,8 +250,8 @@ function traverseTree(
   if (node.completedBy && node.children.length === 0) {
     const tacticId = `tactic-completing-${node.goal.id}`;
     const tacticPosition = {
-      x: position.x,
-      y: position.y + NODE_HEIGHT + 50,
+      x: position.x + (NODE_WIDTH - TACTIC_NODE_WIDTH) / 2,
+      y: position.y + NODE_HEIGHT + GOAL_TO_TACTIC_GAP,
     };
 
     const tacticNode: TacticNode = {
@@ -261,6 +273,8 @@ function traverseTree(
       id: `edge-${nanoid(8)}`,
       source: node.goal.id,
       target: tacticId,
+      sourceHandle: "goal-output",
+      targetHandle: "goal-input",
       data: { kind: "goal-to-tactic" },
     });
   }

--- a/web-react/src/features/proof-editor/utils/convert-proof-tree.ts
+++ b/web-react/src/features/proof-editor/utils/convert-proof-tree.ts
@@ -14,19 +14,19 @@ import type {
 } from "@pie/protocol";
 import { nanoid } from "nanoid";
 
-// Layout constants
-// NODE_WIDTH/HEIGHT are estimates used for spacing calculations.
-// Goals can be 200–320px wide (wider when displaying longer types or context vars),
-// and 120–220px tall depending on how many context entries they show.
-// Using conservative over-estimates prevents sibling overlap at the cost of
-// slightly more whitespace.
-const NODE_WIDTH = 280;          // goal node width estimate
-const NODE_HEIGHT = 175;         // goal node height estimate (includes ~2 context vars)
-const TACTIC_NODE_WIDTH = 200;   // tactic node width estimate
-const TACTIC_NODE_HEIGHT = 80;   // tactic node height estimate
+// Layout constants — used as fallbacks when measured node sizes are not yet
+// available (first render pass).  Kept as conservative over-estimates so the
+// initial placement is "at worst slightly too spread out" rather than overlapping.
+const NODE_WIDTH = 280;          // goal node width fallback
+const NODE_HEIGHT = 175;         // goal node height fallback (includes ~2 context vars)
+const TACTIC_NODE_WIDTH = 200;   // tactic node width fallback
+const TACTIC_NODE_HEIGHT = 80;   // tactic node height fallback
 const HORIZONTAL_SPACING = 80;   // gap between sibling subtrees
 const GOAL_TO_TACTIC_GAP = 30;   // gap from goal bottom to tactic top
 const TACTIC_TO_GOAL_GAP = 40;   // gap from tactic bottom to child goal tops
+
+// Convenience alias used throughout
+type SizeMap = Map<string, { width: number; height: number }>;
 
 interface ConversionResult {
   nodes: ProofNode[];
@@ -47,8 +47,8 @@ export function convertProofTreeToReactFlow(
   const nodes: ProofNode[] = [];
   const edges: ProofEdge[] = [];
 
-  // Calculate positions using tree layout
-  const positions = calculateTreeLayout(proofTree.root);
+  // First-pass layout — uses fallback constants (no measured sizes yet)
+  const positions = computeTreeLayout(proofTree.root);
 
   // Traverse the tree and create nodes/edges
   traverseTree(
@@ -63,52 +63,63 @@ export function convertProofTreeToReactFlow(
 }
 
 /**
- * Calculate positions for all nodes in the tree using a simple layout algorithm.
- * Returns a map from goal ID to position.
+ * Compute positions for all nodes in the proof tree.
+ *
+ * Exported so that a post-render hook can call it a second time with the
+ * actual measured node sizes from React Flow, replacing the fallback estimates
+ * used in the first pass.
+ *
+ * @param root         Root of the proof tree (from protocol)
+ * @param measuredSizes Optional map of nodeId → actual rendered { width, height }.
+ *                      When absent the constant fallbacks above are used.
  */
-function calculateTreeLayout(
+export function computeTreeLayout(
   root: ProtoGoalNode,
+  measuredSizes?: SizeMap,
 ): Map<string, { x: number; y: number }> {
-  const positions = new Map<string, { x: number; y: number }>();
-
-  // First pass: calculate subtree widths
   const widths = new Map<string, number>();
-  calculateSubtreeWidths(root, widths);
+  calculateSubtreeWidths(root, widths, measuredSizes);
 
-  // Second pass: assign positions
-  assignPositions(root, 0, 0, widths, positions);
+  const positions = new Map<string, { x: number; y: number }>();
+  assignPositions(root, 0, 0, widths, positions, measuredSizes);
 
   return positions;
 }
 
 /**
- * Calculate the width of each subtree (for horizontal spacing)
+ * First pass: calculate the allocated width of each subtree.
+ * Uses actual measured widths when available, constants otherwise.
  */
 function calculateSubtreeWidths(
   node: ProtoGoalNode,
   widths: Map<string, number>,
+  measuredSizes?: SizeMap,
 ): number {
+  const goalW = measuredSizes?.get(node.goal.id)?.width ?? NODE_WIDTH;
+
   if (node.children.length === 0) {
-    const width = NODE_WIDTH;
-    widths.set(node.goal.id, width);
-    return width;
+    widths.set(node.goal.id, goalW);
+    return goalW;
   }
 
-  let totalWidth = 0;
+  const tacticId = node.appliedTactic ? `tactic-for-${node.goal.id}` : null;
+  const tacticW = tacticId
+    ? (measuredSizes?.get(tacticId)?.width ?? TACTIC_NODE_WIDTH)
+    : TACTIC_NODE_WIDTH;
+
+  let totalChildrenWidth = 0;
   for (const child of node.children) {
-    totalWidth += calculateSubtreeWidths(child, widths);
+    totalChildrenWidth += calculateSubtreeWidths(child, widths, measuredSizes);
   }
-  // Add spacing between children
-  totalWidth += (node.children.length - 1) * HORIZONTAL_SPACING;
+  totalChildrenWidth += (node.children.length - 1) * HORIZONTAL_SPACING;
 
-  // Width is at least the node width
-  const width = Math.max(NODE_WIDTH, totalWidth);
+  const width = Math.max(goalW, tacticW, totalChildrenWidth);
   widths.set(node.goal.id, width);
   return width;
 }
 
 /**
- * Assign positions to nodes based on their subtree widths
+ * Second pass: assign x/y positions using allocated widths and measured heights.
  */
 function assignPositions(
   node: ProtoGoalNode,
@@ -116,42 +127,44 @@ function assignPositions(
   y: number,
   widths: Map<string, number>,
   positions: Map<string, { x: number; y: number }>,
+  measuredSizes?: SizeMap,
 ): void {
-  const nodeWidth = widths.get(node.goal.id) || NODE_WIDTH;
+  const allocatedWidth = widths.get(node.goal.id) ?? NODE_WIDTH;
+  const goalW = measuredSizes?.get(node.goal.id)?.width ?? NODE_WIDTH;
+  const goalH = measuredSizes?.get(node.goal.id)?.height ?? NODE_HEIGHT;
 
-  // Center this node within its allocated space
-  const nodeX = x + nodeWidth / 2 - NODE_WIDTH / 2;
+  // Center goal within its allocated column
+  const nodeX = x + allocatedWidth / 2 - goalW / 2;
   positions.set(node.goal.id, { x: nodeX, y });
 
   if (node.children.length === 0) return;
 
-  // Tactic sits below the goal with GOAL_TO_TACTIC_GAP clearance.
-  // Children sit below the tactic with TACTIC_TO_GOAL_GAP clearance.
-  const tacticY = y + NODE_HEIGHT + GOAL_TO_TACTIC_GAP;
-  const childrenY = tacticY + TACTIC_NODE_HEIGHT + TACTIC_TO_GOAL_GAP;
+  const tacticId = `tactic-for-${node.goal.id}`;
+  const tacticW = measuredSizes?.get(tacticId)?.width ?? TACTIC_NODE_WIDTH;
+  const tacticH = measuredSizes?.get(tacticId)?.height ?? TACTIC_NODE_HEIGHT;
+
+  // Stack: goal → gap → tactic → gap → children
+  const tacticY = y + goalH + GOAL_TO_TACTIC_GAP;
+  const childrenY = tacticY + tacticH + TACTIC_TO_GOAL_GAP;
 
   const totalChildrenWidth =
     node.children.reduce(
-      (sum, child) => sum + (widths.get(child.goal.id) || NODE_WIDTH),
+      (sum, child) => sum + (widths.get(child.goal.id) ?? NODE_WIDTH),
       0,
     ) +
     (node.children.length - 1) * HORIZONTAL_SPACING;
 
-  // Center children span under the allocated space
-  let childX = x + (nodeWidth - totalChildrenWidth) / 2;
+  let childX = x + (allocatedWidth - totalChildrenWidth) / 2;
 
-  // Center tactic over the children span (independent of goal width)
   if (node.appliedTactic) {
-    const tacticId = `tactic-for-${node.goal.id}`;
-    const tacticX = x + nodeWidth / 2 - TACTIC_NODE_WIDTH / 2;
+    const tacticX = x + allocatedWidth / 2 - tacticW / 2;
     positions.set(tacticId, { x: tacticX, y: tacticY });
   }
 
-  // Position each child
   for (const child of node.children) {
-    const childWidth = widths.get(child.goal.id) || NODE_WIDTH;
-    assignPositions(child, childX, childrenY, widths, positions);
-    childX += childWidth + HORIZONTAL_SPACING;
+    const childAllocated = widths.get(child.goal.id) ?? NODE_WIDTH;
+    assignPositions(child, childX, childrenY, widths, positions, measuredSizes);
+    childX += childAllocated + HORIZONTAL_SPACING;
   }
 }
 

--- a/web-react/src/workers/diagnostics-worker.ts
+++ b/web-react/src/workers/diagnostics-worker.ts
@@ -77,11 +77,14 @@ function rangeFromLocation(location: any): Range {
   const end = location?.syntax?.end ?? location?.end;
 
   if (start && end) {
+    const startColumn = start.column;
+    const endColumn = end.column;
+
     return {
-      startLine: start.line + 1,
-      startColumn: start.column + 1,
-      endLine: end.line + 1,
-      endColumn: end.column + 1,
+      startLine: start.line,
+      startColumn,
+      endLine: end.line,
+      endColumn: Math.max(endColumn + 1, startColumn + 1),
     };
   }
 
@@ -241,7 +244,7 @@ async function buildContextUncached(sourceCode: string) {
     addDefineTacticallyToContext,
   } = contextModule;
   const { go, stop } = utilsModule;
-  const { checkSame } = representModule;
+  const { checkSame, represent } = representModule;
   const { TypeDefinition } = typeDefinitionModule;
 
   let ctx = new Map(initCtx);
@@ -309,6 +312,8 @@ async function buildContextUncached(sourceCode: string) {
         const normalized = declaration.normalizeConstructor(ctx, renaming);
         ctx = normalized[0];
         renaming = normalized[1];
+      } else {
+        result = represent(ctx, declaration as Parameters<typeof represent>[1]);
       }
 
       if (result instanceof stop) {

--- a/web-react/src/workers/diagnostics-worker.ts
+++ b/web-react/src/workers/diagnostics-worker.ts
@@ -163,17 +163,17 @@ const PIE_COMPLETIONS: CompletionItem[] = [
 
 function extractUserSymbols(sourceCode: string): CompletionItem[] {
   const items: CompletionItem[] = [];
-  const add = (label: string, detail: string) => {
+  const add = (label: string, kind: CompletionItem['kind'], detail: string) => {
     if (label && !items.some((item) => item.label === label)) {
-      items.push({ label, kind: 'function', detail });
+      items.push({ label, kind, detail });
     }
   };
 
   for (const match of sourceCode.matchAll(/\(\s*claim\s+([^\s()]+)/g)) {
-    add(match[1], 'User claim');
+    add(match[1], 'type', 'User claim');
   }
   for (const match of sourceCode.matchAll(/\(\s*define\s+([^\s()]+)/g)) {
-    add(match[1], 'User definition');
+    add(match[1], 'function', 'User definition');
   }
 
   return items;

--- a/web-react/src/workers/diagnostics-worker.ts
+++ b/web-react/src/workers/diagnostics-worker.ts
@@ -176,15 +176,55 @@ function extractUserSymbols(sourceCode: string): CompletionItem[] {
   return items;
 }
 
-async function buildContext(sourceCode: string) {
-  const [parserModule, contextModule, utilsModule, representModule, typeDefinitionModule] =
-    await Promise.all([
+let pieModulesPromise: ReturnType<typeof loadPieModules> | null = null;
+
+function loadPieModules() {
+  if (!pieModulesPromise) {
+    pieModulesPromise = Promise.all([
       import('@pie/parser/parser'),
       import('@pie/utils/context'),
       import('@pie/types/utils'),
       import('@pie/typechecker/represent'),
       import('@pie/typechecker/type-definition'),
-    ]);
+    ]).then(([
+      parserModule,
+      contextModule,
+      utilsModule,
+      representModule,
+      typeDefinitionModule,
+    ]) => ({
+      parserModule,
+      contextModule,
+      utilsModule,
+      representModule,
+      typeDefinitionModule,
+    }));
+  }
+
+  return pieModulesPromise;
+}
+
+let cachedSourceCode: string | null = null;
+let cachedBuildContext: ReturnType<typeof buildContextUncached> | null = null;
+
+function buildContext(sourceCode: string) {
+  if (cachedSourceCode === sourceCode && cachedBuildContext) {
+    return cachedBuildContext;
+  }
+
+  cachedSourceCode = sourceCode;
+  cachedBuildContext = buildContextUncached(sourceCode);
+  return cachedBuildContext;
+}
+
+async function buildContextUncached(sourceCode: string) {
+  const {
+    parserModule,
+    contextModule,
+    utilsModule,
+    representModule,
+    typeDefinitionModule,
+  } = await loadPieModules();
 
   const {
     schemeParse,
@@ -204,7 +244,7 @@ async function buildContext(sourceCode: string) {
   const { checkSame } = representModule;
   const { TypeDefinition } = typeDefinitionModule;
 
-  let ctx = initCtx;
+  let ctx = new Map(initCtx);
   let renaming = new Map<string, string>();
   const diagnostics: Diagnostic[] = [];
   let parseSuccessful = true;

--- a/web-react/src/workers/diagnostics-worker.ts
+++ b/web-react/src/workers/diagnostics-worker.ts
@@ -64,25 +64,279 @@ export interface CompletionItem {
   insertText?: string;
 }
 
-// Stub implementation - to be replaced with actual Pie integration
-const diagnosticsWorkerAPI: DiagnosticsWorkerAPI = {
-  async checkSource(_sourceCode) {
-    // TODO: Integrate with Pie interpreter
+function cleanDiagnosticMessage(message: string): string {
+  return message
+    .replace(/^Error:\s*/i, '')
+    .replace(/\s+/g, ' ')
+    .trim();
+}
+
+// eslint-disable-next-line @typescript-eslint/no-explicit-any
+function rangeFromLocation(location: any): Range {
+  const start = location?.syntax?.start ?? location?.start;
+  const end = location?.syntax?.end ?? location?.end;
+
+  if (start && end) {
     return {
-      diagnostics: [],
-      parseSuccessful: true,
-      typeCheckSuccessful: true,
+      startLine: start.line + 1,
+      startColumn: start.column + 1,
+      endLine: end.line + 1,
+      endColumn: end.column + 1,
     };
+  }
+
+  return {
+    startLine: 1,
+    startColumn: 1,
+    endLine: 1,
+    endColumn: 2,
+  };
+}
+
+function messageToText(message: { toString(): string } | string): string {
+  return cleanDiagnosticMessage(
+    typeof message === 'string' ? message : message.toString(),
+  );
+}
+
+function tokenAt(sourceCode: string, line: number, column: number): string {
+  const text = sourceCode.split('\n')[line - 1] ?? '';
+  const index = Math.max(0, column - 1);
+  const left = text.slice(0, index);
+  const right = text.slice(index);
+  const prefix = /[^\s()"]+$/.exec(left)?.[0] ?? '';
+  const suffix = /^[^\s()"]+/.exec(right)?.[0] ?? '';
+  return `${prefix}${suffix}`;
+}
+
+function completionPrefix(sourceCode: string, line: number, column: number): string {
+  const text = sourceCode.split('\n')[line - 1] ?? '';
+  return /[^\s()"]+$/.exec(text.slice(0, Math.max(0, column - 1)))?.[0] ?? '';
+}
+
+const PIE_COMPLETIONS: CompletionItem[] = [
+  { label: 'claim', kind: 'keyword', detail: 'Declare a claim', insertText: '(claim ${1:name} ${2:type})' },
+  { label: 'define', kind: 'keyword', detail: 'Define a value', insertText: '(define ${1:name} ${2:expr})' },
+  { label: 'define-tactically', kind: 'keyword', detail: 'Prove a claim with tactics', insertText: '(define-tactically ${1:name}\n  (${2:tactics}))' },
+  { label: 'Nat', kind: 'type', detail: 'Natural numbers' },
+  { label: 'Atom', kind: 'type', detail: 'Atoms' },
+  { label: 'Trivial', kind: 'type', detail: 'The trivial type' },
+  { label: 'Absurd', kind: 'type', detail: 'The empty type' },
+  { label: 'U', kind: 'type', detail: 'Universe of types' },
+  { label: 'Pi', kind: 'type', detail: 'Dependent function type', insertText: '(Pi ((${1:x} ${2:A}))\n  ${3:B})' },
+  { label: 'Sigma', kind: 'type', detail: 'Dependent pair type', insertText: '(Sigma ((${1:x} ${2:A}))\n  ${3:B})' },
+  { label: 'Pair', kind: 'type', detail: 'Pair type', insertText: '(Pair ${1:A} ${2:B})' },
+  { label: 'Either', kind: 'type', detail: 'Either type', insertText: '(Either ${1:L} ${2:R})' },
+  { label: 'List', kind: 'type', detail: 'List type', insertText: '(List ${1:E})' },
+  { label: 'Vec', kind: 'type', detail: 'Vector type', insertText: '(Vec ${1:E} ${2:n})' },
+  { label: '=', kind: 'type', detail: 'Equality type', insertText: '(= ${1:A} ${2:from} ${3:to})' },
+  { label: '->', kind: 'type', detail: 'Function type', insertText: '(-> ${1:A} ${2:B})' },
+  { label: 'lambda', kind: 'keyword', detail: 'Lambda expression', insertText: '(lambda (${1:x}) ${2:body})' },
+  { label: 'the', kind: 'keyword', detail: 'Type annotation', insertText: '(the ${1:type} ${2:expr})' },
+  { label: 'zero', kind: 'variable', detail: 'Zero' },
+  { label: 'add1', kind: 'function', detail: 'Successor', insertText: '(add1 ${1:n})' },
+  { label: 'same', kind: 'function', detail: 'Reflexivity proof', insertText: '(same ${1:expr})' },
+  { label: 'sole', kind: 'variable', detail: 'Trivial inhabitant' },
+  { label: 'nil', kind: 'variable', detail: 'Empty list' },
+  { label: '::', kind: 'function', detail: 'List cons', insertText: '(:: ${1:head} ${2:tail})' },
+  { label: 'cons', kind: 'function', detail: 'Pair constructor', insertText: '(cons ${1:car} ${2:cdr})' },
+  { label: 'car', kind: 'function', detail: 'Pair first projection', insertText: '(car ${1:pair})' },
+  { label: 'cdr', kind: 'function', detail: 'Pair second projection', insertText: '(cdr ${1:pair})' },
+  { label: 'left', kind: 'function', detail: 'Either left injection', insertText: '(left ${1:value})' },
+  { label: 'right', kind: 'function', detail: 'Either right injection', insertText: '(right ${1:value})' },
+  { label: 'intro', kind: 'function', detail: 'Introduce a variable', insertText: '(intro ${1:name})' },
+  { label: 'exact', kind: 'function', detail: 'Provide exact proof term', insertText: '(exact ${1:expr})' },
+  { label: 'exists', kind: 'function', detail: 'Provide Sigma witness', insertText: '(exists ${1:witness})' },
+  { label: 'split-Pair', kind: 'function', detail: 'Split a Sigma/Pair goal' },
+  { label: 'elim-Nat', kind: 'function', detail: 'Eliminate Nat', insertText: '(elim-Nat ${1:n})' },
+  { label: 'elim-List', kind: 'function', detail: 'Eliminate List', insertText: '(elim-List ${1:xs})' },
+  { label: 'elim-Vec', kind: 'function', detail: 'Eliminate Vec', insertText: '(elim-Vec ${1:xs})' },
+  { label: 'elim-Either', kind: 'function', detail: 'Eliminate Either', insertText: '(elim-Either ${1:e})' },
+  { label: 'elim-Equal', kind: 'function', detail: 'Eliminate equality', insertText: '(elim-Equal ${1:eq})' },
+  { label: 'elim-Absurd', kind: 'function', detail: 'Eliminate Absurd', insertText: '(elim-Absurd ${1:x})' },
+  { label: 'apply', kind: 'function', detail: 'Apply a theorem or function', insertText: '(apply ${1:expr})' },
+  { label: 'then', kind: 'keyword', detail: 'Branch tactic block', insertText: '(then\n  ${1:tactic})' },
+];
+
+function extractUserSymbols(sourceCode: string): CompletionItem[] {
+  const items: CompletionItem[] = [];
+  const add = (label: string, detail: string) => {
+    if (label && !items.some((item) => item.label === label)) {
+      items.push({ label, kind: 'function', detail });
+    }
+  };
+
+  for (const match of sourceCode.matchAll(/\(\s*claim\s+([^\s()]+)/g)) {
+    add(match[1], 'User claim');
+  }
+  for (const match of sourceCode.matchAll(/\(\s*define\s+([^\s()]+)/g)) {
+    add(match[1], 'User definition');
+  }
+
+  return items;
+}
+
+async function buildContext(sourceCode: string) {
+  const [parserModule, contextModule, utilsModule, representModule, typeDefinitionModule] =
+    await Promise.all([
+      import('@pie/parser/parser'),
+      import('@pie/utils/context'),
+      import('@pie/types/utils'),
+      import('@pie/typechecker/represent'),
+      import('@pie/typechecker/type-definition'),
+    ]);
+
+  const {
+    schemeParse,
+    pieDeclarationParser,
+    Claim,
+    Definition,
+    SamenessCheck,
+    DefineTactically,
+  } = parserModule;
+  const {
+    initCtx,
+    addClaimToContext,
+    addDefineToContext,
+    addDefineTacticallyToContext,
+  } = contextModule;
+  const { go, stop } = utilsModule;
+  const { checkSame } = representModule;
+  const { TypeDefinition } = typeDefinitionModule;
+
+  let ctx = initCtx;
+  let renaming = new Map<string, string>();
+  const diagnostics: Diagnostic[] = [];
+  let parseSuccessful = true;
+  let typeCheckSuccessful = true;
+
+  let astList: unknown[];
+  try {
+    astList = schemeParse(sourceCode) as unknown[];
+  } catch (error) {
+    return {
+      ctx,
+      diagnostics: [{
+        severity: 'error' as const,
+        message: cleanDiagnosticMessage(error instanceof Error ? error.message : 'Failed to parse source'),
+        range: rangeFromLocation(
+          // eslint-disable-next-line @typescript-eslint/no-explicit-any
+          (error as any)?.location,
+        ),
+        source: 'parser' as const,
+      }],
+      parseSuccessful: false,
+      typeCheckSuccessful: false,
+    };
+  }
+
+  for (const ast of astList) {
+    let declaration: unknown;
+
+    try {
+      // eslint-disable-next-line @typescript-eslint/no-explicit-any
+      declaration = pieDeclarationParser.parseDeclaration(ast as any);
+    } catch (error) {
+      parseSuccessful = false;
+      typeCheckSuccessful = false;
+      diagnostics.push({
+        severity: 'error',
+        message: cleanDiagnosticMessage(error instanceof Error ? error.message : 'Failed to parse declaration'),
+        range: rangeFromLocation(
+          // eslint-disable-next-line @typescript-eslint/no-explicit-any
+          (ast as any)?.location,
+        ),
+        source: 'parser',
+      });
+      continue;
+    }
+
+    try {
+      let result: unknown = null;
+
+      if (declaration instanceof Claim) {
+        result = addClaimToContext(ctx, declaration.name, declaration.location, declaration.type);
+        if (result instanceof go) ctx = result.result;
+      } else if (declaration instanceof Definition) {
+        result = addDefineToContext(ctx, declaration.name, declaration.location, declaration.expr);
+        if (result instanceof go) ctx = result.result;
+      } else if (declaration instanceof DefineTactically) {
+        result = addDefineTacticallyToContext(ctx, declaration.name, declaration.location, declaration.tactics);
+        if (result instanceof go) ctx = result.result.context;
+      } else if (declaration instanceof SamenessCheck) {
+        result = checkSame(ctx, declaration.location, declaration.type, declaration.left, declaration.right);
+      } else if (declaration instanceof TypeDefinition) {
+        const normalized = declaration.normalizeConstructor(ctx, renaming);
+        ctx = normalized[0];
+        renaming = normalized[1];
+      }
+
+      if (result instanceof stop) {
+        typeCheckSuccessful = false;
+        diagnostics.push({
+          severity: 'error',
+          message: messageToText(result.message),
+          range: rangeFromLocation(result.where),
+          source: 'typechecker',
+        });
+      }
+    } catch (error) {
+      typeCheckSuccessful = false;
+      diagnostics.push({
+        severity: 'error',
+        message: cleanDiagnosticMessage(error instanceof Error ? error.message : 'Failed to check declaration'),
+        range: rangeFromLocation(
+          // eslint-disable-next-line @typescript-eslint/no-explicit-any
+          (declaration as any)?.location,
+        ),
+        source: 'typechecker',
+      });
+    }
+  }
+
+  diagnostics.sort((a, b) => (
+    a.range.startLine === b.range.startLine
+      ? a.range.startColumn - b.range.startColumn
+      : a.range.startLine - b.range.startLine
+  ));
+
+  return { ctx, diagnostics, parseSuccessful, typeCheckSuccessful };
+}
+
+const diagnosticsWorkerAPI: DiagnosticsWorkerAPI = {
+  async checkSource(sourceCode) {
+    const { diagnostics, parseSuccessful, typeCheckSuccessful } =
+      await buildContext(sourceCode);
+    return { diagnostics, parseSuccessful, typeCheckSuccessful };
   },
 
-  async getHoverInfo(_sourceCode, _line, _column) {
-    // TODO: Integrate with Pie interpreter
-    return null;
+  async getHoverInfo(sourceCode, line, column) {
+    const token = tokenAt(sourceCode, line, column);
+    if (!token) return null;
+
+    try {
+      const { ctx } = await buildContext(sourceCode);
+      const binder = ctx.get(token);
+      if (!binder) return null;
+      return {
+        type: binder.type.readBackType(ctx).prettyPrint(),
+        documentation: token,
+      };
+    } catch {
+      return null;
+    }
   },
 
-  async getCompletions(_sourceCode, _line, _column) {
-    // TODO: Integrate with Pie interpreter
-    return [];
+  async getCompletions(sourceCode, line, column) {
+    const prefix = completionPrefix(sourceCode, line, column).toLowerCase();
+    const allItems = [...PIE_COMPLETIONS, ...extractUserSymbols(sourceCode)];
+    const seen = new Set<string>();
+
+    return allItems.filter((item) => {
+      if (seen.has(item.label)) return false;
+      seen.add(item.label);
+      return !prefix || item.label.toLowerCase().startsWith(prefix);
+    });
   },
 };
 


### PR DESCRIPTION
## Summary

Fixes bugs in the AI-visual proof editor: AI hint canvas interactions, tactic layout engine, diagnostics accuracy, and tactic parameter UI.

## What this PR does

- **AI hint flow**: stabilise AI hint sessions; fix canvas interactions (goal selection, hint card positioning)
- **Layout engine**: replace hardcoded constants with measured two-pass layout; fix overlapping tactic nodes and connector handles
- **Diagnostics**: tighten error reporting; fix dependent-split edge cases
- **Tactic parameter UI**: fix `intro` tactic parameter input; generalise `ExactParamInput` → `ExpressionParamInput` to support `exists` and `apply` tactics

## Files changed (key)

| File | Change |
|------|--------|
| `ProofCanvas.tsx` | AI hint canvas interactions |
| `TacticNode.tsx` | ExpressionParamInput for exists/apply; fix intro |
| `convert-proof-tree.ts` | Two-pass measured layout |
| `diagnostics-worker.ts` | Tightened diagnostics |
| `useAutoLayout.ts` | Layout engine fixes |
| `proof-store.ts` | AI hint state |
| `describeGoalBrowser.ts` | AI goal description |

## Merge order

**Depends on:** #174 (aesthetics) and #172 (Monaco editor). Merge after both.

**Depended on by:** #190, #191.

Recommended merge order: **`#174 → #172 → #188 → #187 → #190 → #191`**

## Conflict resolution (merge this after #174 + #172)

When merging #187 onto (#174 + #172), **8 files will conflict**. Resolution varies by file:

### Files: take `#187` (incoming/theirs)

These files in `#187` match the final `demo` state exactly. Overwrite with `--theirs`:

```bash
git checkout --theirs \
  web-react/src/features/proof-editor/components/ProofCanvas.tsx \
  web-react/src/features/proof-editor/components/nodes/TacticNode.tsx \
  web-react/src/features/proof-editor/utils/convert-proof-tree.ts \
  web-react/src/workers/diagnostics-worker.ts
```

| File | Why |
|------|-----|
| `ProofCanvas.tsx` | `#187` adds AI hint canvas interactions on top of `#174`'s layout |
| `TacticNode.tsx` | `#187` fixes `intro` param + adds `exists`/`apply` expression input |
| `convert-proof-tree.ts` | `#187` replaces hardcoded layout constants with two-pass measurement |
| `diagnostics-worker.ts` | `#187` adds tightened diagnostics on top of `#172`'s Monaco wiring |

### Files: take `#174 + #172` (current/ours)

`#187` was branched from `ai-visual` before the aesthetics redesign was merged, so its versions of these files are older. Keep the current HEAD:

```bash
git checkout --ours \
  web-react/src/app/App.tsx \
  web-react/src/features/proof-editor/components/panels/SourceCodePanel.tsx \
  web-react/src/features/proof-editor/components/panels/DetailPanel.tsx \
  web-react/src/features/proof-editor/components/panels/TacticPalette.tsx
```

| File | Why |
|------|-----|
| `App.tsx` | `#174`'s richer layout (264 lines) vs `#187`'s older version (165 lines) |
| `SourceCodePanel.tsx` | `#174`'s Monaco panel is the base `#190` builds on |
| `DetailPanel.tsx` | `#187` has old 47-line stub; `#190` will expand to 536 lines |
| `TacticPalette.tsx` | `#174` and demo both use 97-line version; `#187` has an unrelated 166-line variant |

Then commit:

```bash
git add -A
git commit -m "Merge #187 fix/aivisual-bugs"
```

## AI Declaration

This implementation was designed and generated with the assistance of **Codex / ChatGPT 5.4** by OpenAI.