### PR TITLE
feat(proof-editor): redesign History tab as proof journal

### DIFF
--- a/web-react/src/features/proof-editor/components/panels/DetailPanel.tsx
+++ b/web-react/src/features/proof-editor/components/panels/DetailPanel.tsx
@@ -1,47 +1,536 @@
-import { useProofStore, useUIStore } from '../../store';
-import { GoalDetailPanel } from './GoalDetailPanel';
-import { TacticDetailPanel } from './TacticDetailPanel';
+import { useState, useCallback, useEffect, useMemo } from 'react';
+import { useProofStore, useUIStore, useGeneratedProofScript, useIsProofComplete } from '../../store';
+import type { GoalNode, TacticNode } from '../../store/types';
+import { TACTICS } from '../../data/tactics';
+import type { TacticCategory } from '../../data/tactics';
+import { applyTactic } from '../../utils/tactic-callback';
+import { useHintStore } from '../../store/hint-store';
+import { useMetadataStore } from '../../store/metadata-store';
+import { useGoalDescriptionStore } from '../../store/goal-description-store';
+import { describeGoalBrowser } from '../../lib/describeGoalBrowser';
+import type { GlobalEntry } from '@pie/protocol';
 
-/**
- * DetailPanel Component
- *
- * Unified side panel that shows details for the selected node.
- * Switches between GoalDetailPanel and TacticDetailPanel based on node type.
- */
-export function DetailPanel() {
-  const selectedNodeId = useUIStore((s) => s.selectedNodeId);
-  const nodes = useProofStore((s) => s.nodes);
+interface DetailPanelProps {
+  definitions?: GlobalEntry[];
+  theorems?: GlobalEntry[];
+}
 
-  // Find the selected node to determine which panel to show
-  const selectedNode = nodes.find((n) => n.id === selectedNodeId);
+type Tab = 'details' | 'context' | 'history';
 
-  // No selection - show placeholder
-  if (!selectedNode) {
-    return (
-      <div className="w-80 border-l bg-gray-50 p-4">
-        <p className="text-sm text-gray-500">
-          Click on a node to see details
-        </p>
-      </div>
-    );
-  }
+// Category dot colors match the tactic palette glyphs
+const CATEGORY_COLOR: Record<TacticCategory, string> = {
+  introduction: '#2563eb',
+  constructor:  '#16a34a',
+  elimination:  '#7c3aed',
+  application:  '#ea580c',
+  placeholder:  '#94a3b8',
+};
 
-  // Show appropriate panel based on node type
-  switch (selectedNode.type) {
-    case 'goal':
-      return <GoalDetailPanel />;
-    case 'tactic':
-      return <TacticDetailPanel />;
-    case 'lemma':
-      // TODO: LemmaDetailPanel
-      return (
-        <div className="w-80 border-l bg-gray-50 p-4">
-          <p className="text-sm text-gray-500">
-            Lemma details coming soon
-          </p>
-        </div>
+function getCategoryColor(displayName: string): string {
+  const tactic = TACTICS.find(t => t.type === displayName);
+  return tactic ? CATEGORY_COLOR[tactic.category] : '#94a3b8';
+}
+
+function getSuggestedTactics(goalType: string): string[] {
+  const suggestions: string[] = [];
+  if (goalType.includes('Pi') || goalType.includes('->')) suggestions.push('intro');
+  if (goalType.includes('Sigma') || goalType.includes('Pair')) suggestions.push('split', 'exists');
+  if (goalType.includes('Either')) suggestions.push('left', 'right');
+  if (goalType.includes('= Nat') || goalType.includes('Nat')) suggestions.push('elimNat', 'exact');
+  if (goalType.includes('= ')) suggestions.push('symm', 'cong');
+  suggestions.push('exact');
+  return [...new Set(suggestions)].slice(0, 5);
+}
+
+function getErrorMessage(e: unknown): string {
+  if (e instanceof Error) return e.message;
+  if (typeof e === 'string') return e;
+  try { return JSON.stringify(e); } catch { return 'Unknown error'; }
+}
+
+// ── AI Overview Section ───────────────────────────────────────────────────────
+
+function AIOverview({ goalNode }: { goalNode: GoalNode }) {
+  const apiKey = useHintStore((s) => s.apiKey);
+  const sourceCode = useMetadataStore((s) => s.sourceCode);
+  const claimName = useMetadataStore((s) => s.claimName);
+  const setLoading = useGoalDescriptionStore((s) => s.setLoading);
+  const setDescription = useGoalDescriptionStore((s) => s.setDescription);
+  const setError = useGoalDescriptionStore((s) => s.setError);
+  const rawEntry = useGoalDescriptionStore((s) => s.descriptions.get(goalNode.id));
+
+  const signature = useMemo(() => {
+    if (!sourceCode || !claimName) return null;
+    const ctxKey = goalNode.data.context.map(e => `${e.name}:${e.type}`).join(',');
+    return `${claimName}\x00${goalNode.data.goalType}\x00${ctxKey}\x00${sourceCode}`;
+  }, [goalNode.data.context, goalNode.data.goalType, sourceCode, claimName]);
+
+  const entry = rawEntry?.signature === signature ? rawEntry : undefined;
+
+  const fetch = useCallback(async () => {
+    if (!apiKey || !sourceCode || !claimName || !signature) return;
+    setLoading(goalNode.id, signature);
+    try {
+      const text = await describeGoalBrowser(
+        {
+          pieCode: sourceCode,
+          claimName,
+          goalType: goalNode.data.goalType,
+          context: goalNode.data.context.map(e => ({ name: e.name, type: e.type })),
+        },
+        apiKey,
       );
-    default:
-      return null;
-  }
+      setDescription(goalNode.id, signature, text);
+    } catch (e) {
+      setError(goalNode.id, signature, getErrorMessage(e));
+    }
+  }, [apiKey, sourceCode, claimName, signature, goalNode.id, goalNode.data, setLoading, setDescription, setError]);
+
+  // Auto-fetch on first open
+  useEffect(() => {
+    if (apiKey && sourceCode && claimName && signature && !entry) {
+      fetch();
+    }
+  }, [apiKey, sourceCode, claimName, signature, entry, fetch]);
+
+  return (
+    <div className="pe-d-section">
+      <div className="pe-d-section-hd">
+        <span className="pe-d-section-label" style={{ display: 'flex', alignItems: 'center', gap: 4 }}>
+          <svg width="11" height="11" viewBox="0 0 12 12" fill="none" style={{ color: 'var(--pe-accent)', flexShrink: 0 }}>
+            <path d="M6 1l1.2 2.8L10 5 7.2 6.2 6 9l-1.2-2.8L2 5l2.8-1.2z" fill="currentColor" />
+          </svg>
+          AI Overview
+        </span>
+        {apiKey && (
+          <button
+            onClick={fetch}
+            disabled={entry?.isLoading}
+            style={{
+              display: 'flex', alignItems: 'center', gap: 3,
+              fontSize: 10.5, padding: '1px 7px', borderRadius: 4,
+              background: 'color-mix(in oklab, var(--pe-accent) 10%, white)',
+              color: 'var(--pe-accent)',
+              border: '1px solid color-mix(in oklab, var(--pe-accent) 22%, white)',
+              cursor: entry?.isLoading ? 'not-allowed' : 'pointer',
+              opacity: entry?.isLoading ? 0.6 : 1,
+            }}
+          >
+            <svg width="10" height="10" viewBox="0 0 10 10" fill="none" stroke="currentColor" strokeWidth="1.6" strokeLinecap="round"
+              style={entry?.isLoading ? { animation: 'spin 0.8s linear infinite' } : undefined}>
+              <path d="M5 1.5A3.5 3.5 0 1 1 1.5 5" />
+              <path d="M1.5 1.5v3h3" />
+            </svg>
+            {entry?.isLoading ? 'Generating…' : 'Refresh'}
+          </button>
+        )}
+      </div>
+
+      {!apiKey ? (
+        <p style={{ fontSize: 11.5, color: 'var(--pe-faint)', fontStyle: 'italic' }}>
+          Configure a Gemini API key in AI Settings (⚙ top-right) to enable goal descriptions.
+        </p>
+      ) : !sourceCode || !claimName ? (
+        <p style={{ fontSize: 11.5, color: 'var(--pe-faint)', fontStyle: 'italic' }}>
+          Start a proof session to generate a description.
+        </p>
+      ) : entry?.isLoading ? (
+        <div style={{ display: 'flex', alignItems: 'center', gap: 6, fontSize: 11.5, color: 'var(--pe-accent)' }}>
+          <svg width="12" height="12" viewBox="0 0 10 10" fill="none" stroke="currentColor" strokeWidth="1.6" strokeLinecap="round"
+            style={{ animation: 'spin 0.8s linear infinite', flexShrink: 0 }}>
+            <path d="M5 1.5A3.5 3.5 0 1 1 1.5 5" /><path d="M1.5 1.5v3h3" />
+          </svg>
+          Generating description…
+        </div>
+      ) : entry?.error ? (
+        <div style={{
+          display: 'flex', alignItems: 'flex-start', gap: 6, padding: '6px 8px', borderRadius: 5,
+          background: 'color-mix(in oklab, var(--pe-err) 8%, white)',
+          border: '1px solid color-mix(in oklab, var(--pe-err) 22%, white)',
+        }}>
+          <svg width="12" height="12" viewBox="0 0 12 12" fill="none" stroke="var(--pe-err)" strokeWidth="1.5" strokeLinecap="round" style={{ flexShrink: 0, marginTop: 1 }}>
+            <circle cx="6" cy="6" r="5" /><path d="M6 4v3M6 8.5v.5" />
+          </svg>
+          <span style={{ fontSize: 11.5, color: 'var(--pe-err)', lineHeight: 1.4 }}>
+            {entry.error.length > 120 ? entry.error.slice(0, 120) + '…' : entry.error}
+          </span>
+        </div>
+      ) : entry?.text ? (
+        <p style={{ fontSize: 12, color: 'var(--pe-ink-2)', lineHeight: 1.55 }}>
+          {entry.text}
+        </p>
+      ) : (
+        <p style={{ fontSize: 11.5, color: 'var(--pe-faint)', fontStyle: 'italic' }}>Fetching…</p>
+      )}
+    </div>
+  );
+}
+
+// ─────────────────────────────────────────────────────────────────────────────
+
+export function DetailPanel({ definitions = [], theorems = [] }: DetailPanelProps) {
+  const [activeTab, setActiveTab] = useState<Tab>('details');
+  const [selectedDef, setSelectedDef] = useState<string | null>(null);
+  const [scriptCopied, setScriptCopied] = useState(false);
+
+  const selectedNodeId = useUIStore((s) => s.selectedNodeId);
+  const selectNode = useUIStore((s) => s.selectNode);
+  const nodes = useProofStore((s) => s.nodes);
+  const claimName = useProofStore((s) => s.claimName);
+  const isProofComplete = useIsProofComplete();
+  const generatedScript = useGeneratedProofScript();
+
+  const selectedNode = nodes.find((n) => n.id === selectedNodeId);
+  const goalNode = selectedNode?.type === 'goal' ? (selectedNode as GoalNode) : null;
+
+  const suggestions = goalNode ? getSuggestedTactics(goalNode.data.goalType) : [];
+
+  const appliedTactics = (nodes.filter(
+    (n) => n.type === 'tactic' && (n.data as TacticNode['data']).status === 'applied'
+  ) as TacticNode[]).sort((a, b) => (a.data.appliedAt ?? 0) - (b.data.appliedAt ?? 0));
+
+  const goalNodes = nodes.filter((n) => n.type === 'goal') as GoalNode[];
+  const totalGoals = goalNodes.length;
+  const completedGoals = goalNodes.filter((n) => n.data.status === 'completed').length;
+
+  const goalMap = new Map(goalNodes.map((n) => [n.id, n]));
+
+  const hasContent = selectedNode || definitions.length > 0 || theorems.length > 0;
+
+  // Script preview: real script when complete, approximation when in progress
+  const scriptText = useMemo(() => {
+    if (generatedScript) return generatedScript;
+    if (appliedTactics.length === 0) return null;
+    const steps = appliedTactics.map(t => `  (${t.data.displayName})`).join('\n');
+    return `(define-tactically ${claimName ?? '?'}\n${steps}\n  ...)`;
+  }, [generatedScript, appliedTactics, claimName]);
+
+  const handleCopyScript = useCallback(() => {
+    if (!scriptText) return;
+    navigator.clipboard.writeText(scriptText).then(() => {
+      setScriptCopied(true);
+      setTimeout(() => setScriptCopied(false), 1800);
+    });
+  }, [scriptText]);
+
+  return (
+    <>
+      {/* Tabs */}
+      <div className="pe-detail-tabs">
+        {(['details', 'context', 'history'] as Tab[]).map((tab) => (
+          <button
+            key={tab}
+            className={`pe-detail-tab${activeTab === tab ? ' active' : ''}`}
+            onClick={() => setActiveTab(tab)}
+          >
+            {tab.charAt(0).toUpperCase() + tab.slice(1)}
+            {tab === 'history' && appliedTactics.length > 0 && (
+              <span style={{
+                marginLeft: 4, fontSize: 9.5, padding: '0px 4px', borderRadius: 99,
+                background: activeTab === 'history' ? 'var(--pe-accent)' : 'var(--pe-line)',
+                color: activeTab === 'history' ? '#fff' : 'var(--pe-ink-2)',
+                fontWeight: 600, verticalAlign: 'middle',
+              }}>
+                {appliedTactics.length}
+              </span>
+            )}
+          </button>
+        ))}
+      </div>
+
+      <div className="pe-detail-body">
+
+        {/* ── DETAILS TAB ── */}
+        {activeTab === 'details' && (
+          <>
+            {selectedNode ? (
+              <div className="pe-d-section" style={{ paddingBottom: 10 }}>
+                <div className="pe-d-section-hd">
+                  <span className="pe-d-section-label">
+                    {selectedNode.type === 'goal'
+                      ? `Goal${goalNode?.data.status ? ` · ${goalNode.data.status}` : ''}`
+                      : selectedNode.type === 'tactic' ? 'Tactic' : selectedNode.type}
+                  </span>
+                  <button
+                    onClick={() => selectNode(null)}
+                    style={{ border: 'none', background: 'none', cursor: 'pointer', color: 'var(--pe-faint)', padding: 2, borderRadius: 3 }}
+                    title="Deselect"
+                  >
+                    <svg width="10" height="10" viewBox="0 0 10 10" fill="none" stroke="currentColor" strokeWidth="1.6" strokeLinecap="round">
+                      <path d="M2 2l6 6M8 2L2 8" />
+                    </svg>
+                  </button>
+                </div>
+
+                {goalNode && (
+                  <>
+                    <div className="pe-big-type">{goalNode.data.goalType}</div>
+                    <div className="pe-meta">
+                      <span><b>ctx</b> {goalNode.data.context.length} var{goalNode.data.context.length !== 1 ? 's' : ''}</span>
+                      {goalNode.data.parentGoalId && (
+                        <span style={{ cursor: 'pointer', color: 'var(--pe-accent)' }}
+                          onClick={() => goalNode.data.parentGoalId && selectNode(goalNode.data.parentGoalId)}>
+                          ↑ parent
+                        </span>
+                      )}
+                    </div>
+                  </>
+                )}
+
+                {selectedNode.type === 'tactic' && (
+                  <div style={{ fontFamily: 'var(--pe-mono-font)', fontSize: 13, fontWeight: 600, color: 'var(--pe-ink)', marginTop: 4 }}>
+                    {(selectedNode.data as { displayName?: string }).displayName ?? 'tactic'}
+                  </div>
+                )}
+              </div>
+            ) : !hasContent && (
+              <div className="pe-d-section" style={{ color: 'var(--pe-faint)', fontSize: 12 }}>
+                Click a node to see details
+              </div>
+            )}
+
+            {/* AI Overview — only when a goal is selected */}
+            {goalNode && <AIOverview goalNode={goalNode} />}
+
+            {/* Suggested tactics */}
+            {goalNode && suggestions.length > 0 && (
+              <div className="pe-d-section">
+                <div className="pe-d-section-hd">
+                  <span className="pe-d-section-label">Suggested tactics</span>
+                </div>
+                <div className="pe-suggested">
+                  {suggestions.map((name) => {
+                    const info = TACTICS.find(t => t.type === name);
+                    const needsCtx = info?.requiresContextVar;
+                    return (
+                      <button
+                        key={name}
+                        className="pe-chip"
+                        title={needsCtx ? `${info?.description ?? name} · drag from palette to connect context` : (info?.description ?? name)}
+                        style={{ cursor: needsCtx ? 'help' : 'pointer', border: 'none', opacity: needsCtx ? 0.6 : 1 }}
+                        onClick={() => {
+                          if (needsCtx) return;
+                          applyTactic(goalNode.id, name as Parameters<typeof applyTactic>[1], {});
+                        }}
+                      >
+                        {name}
+                        {needsCtx && <span style={{ marginLeft: 3, fontSize: 9, color: 'var(--pe-faint)' }}>ctx</span>}
+                      </button>
+                    );
+                  })}
+                </div>
+                <div style={{ fontSize: 10.5, color: 'var(--pe-faint)', marginTop: 4 }}>
+                  Click to apply · <span style={{ opacity: 0.7 }}>ctx</span> tactics need a context variable — drag from palette
+                </div>
+              </div>
+            )}
+
+            {/* Definitions */}
+            {definitions.length > 0 && (
+              <div className="pe-d-section">
+                <div className="pe-d-section-hd">
+                  <span className="pe-d-section-label">Definitions</span>
+                  <span className="pe-d-section-count">{definitions.length}</span>
+                </div>
+                {definitions.map((def) => (
+                  <ContextItem key={def.name} entry={def} kind="def"
+                    isSelected={selectedDef === def.name}
+                    onClick={() => setSelectedDef(selectedDef === def.name ? null : def.name)} />
+                ))}
+              </div>
+            )}
+
+            {/* Theorems & claims */}
+            {theorems.length > 0 && (
+              <div className="pe-d-section">
+                <div className="pe-d-section-hd">
+                  <span className="pe-d-section-label">Theorems &amp; claims</span>
+                  <span className="pe-d-section-count">{theorems.length}</span>
+                </div>
+                {theorems.map((thm) => (
+                  <ContextItem key={thm.name} entry={thm} kind={thm.kind === 'claim' ? 'claim' : 'thm'}
+                    isSelected={selectedDef === thm.name}
+                    onClick={() => setSelectedDef(selectedDef === thm.name ? null : thm.name)} />
+                ))}
+              </div>
+            )}
+
+            {!selectedNode && definitions.length === 0 && theorems.length === 0 && (
+              <div className="pe-d-section" style={{ color: 'var(--pe-faint)', fontSize: 12 }}>
+                No definitions yet · start a proof session to see context
+              </div>
+            )}
+          </>
+        )}
+
+        {/* ── CONTEXT TAB ── */}
+        {activeTab === 'context' && (
+          <>
+            {goalNode ? (
+              <div className="pe-d-section">
+                <div className="pe-d-section-hd">
+                  <span className="pe-d-section-label">Local context</span>
+                  <span className="pe-d-section-count">{goalNode.data.context.length}</span>
+                </div>
+                {goalNode.data.context.length === 0 ? (
+                  <div style={{ color: 'var(--pe-faint)', fontSize: 12, fontStyle: 'italic' }}>No bindings in scope</div>
+                ) : (
+                  goalNode.data.context.map((entry) => (
+                    <div key={entry.id} className="pe-ctx-row">
+                      <span>
+                        <span className="pe-ctx-var">{entry.name}</span>
+                        <span className="pe-ctx-type"> : {entry.type}</span>
+                      </span>
+                      {entry.origin === 'introduced' && (
+                        <span style={{
+                          fontSize: 9.5, padding: '1px 5px', borderRadius: 99,
+                          background: 'color-mix(in oklab, var(--pe-accent) 10%, white)',
+                          color: 'var(--pe-accent)',
+                          border: '1px solid color-mix(in oklab, var(--pe-accent) 22%, white)',
+                          fontFamily: 'var(--pe-mono-font)',
+                        }}>intro</span>
+                      )}
+                    </div>
+                  ))
+                )}
+              </div>
+            ) : (
+              <div className="pe-d-section" style={{ color: 'var(--pe-faint)', fontSize: 12 }}>
+                Select a goal node to see its local context
+              </div>
+            )}
+          </>
+        )}
+
+        {/* ── HISTORY TAB ── */}
+        {activeTab === 'history' && (
+          <>
+            {/* Progress bar */}
+            {totalGoals > 0 && (
+              <div className="pe-hist-progress">
+                <div className="pe-hist-progress-bar">
+                  <div
+                    className="pe-hist-progress-fill"
+                    style={{ width: `${Math.round((completedGoals / totalGoals) * 100)}%` }}
+                  />
+                </div>
+                <span className="pe-hist-progress-label">
+                  {isProofComplete
+                    ? <><span style={{ color: 'var(--pe-ok)', fontWeight: 600 }}>Complete</span> · all {totalGoals} goal{totalGoals !== 1 ? 's' : ''} proved</>
+                    : <><strong>{completedGoals}</strong> / {totalGoals} goal{totalGoals !== 1 ? 's' : ''} proved</>
+                  }
+                </span>
+              </div>
+            )}
+
+            {/* Tactic steps */}
+            {appliedTactics.length === 0 ? (
+              <div className="pe-d-section" style={{ color: 'var(--pe-faint)', fontSize: 12 }}>
+                No tactics applied yet · apply a tactic to see proof steps
+              </div>
+            ) : (
+              <div className="pe-d-section" style={{ paddingBottom: 4 }}>
+                <div className="pe-d-section-hd">
+                  <span className="pe-d-section-label">Steps</span>
+                  <span className="pe-d-section-count">{appliedTactics.length}</span>
+                </div>
+                <div className="pe-hist-steps">
+                  {appliedTactics.map((tactic, idx) => {
+                    const parentGoal = tactic.data.connectedGoalId ? goalMap.get(tactic.data.connectedGoalId) : undefined;
+                    const goalType = parentGoal?.data.goalType ?? '';
+                    const goalComplete = parentGoal?.data.status === 'completed';
+                    const color = getCategoryColor(tactic.data.displayName);
+                    return (
+                      <button
+                        key={tactic.id}
+                        className="pe-hist-row"
+                        onClick={() => selectNode(tactic.id)}
+                        title="Click to select this node on the canvas"
+                      >
+                        {/* Step number */}
+                        <span className="pe-hist-num">{idx + 1}</span>
+                        {/* Category dot */}
+                        <span className="pe-hist-dot" style={{ background: color }} />
+                        {/* Tactic name chip */}
+                        <span className="pe-hist-name" style={{ color }}>
+                          {tactic.data.displayName}
+                        </span>
+                        {/* Goal type (right side) */}
+                        <span className="pe-hist-goal" title={goalType}>
+                          {goalType.length > 22 ? goalType.slice(0, 22) + '…' : goalType}
+                        </span>
+                        {/* Result indicator */}
+                        <span className="pe-hist-result" title={goalComplete ? 'Goal proved' : 'Subgoals open'}>
+                          {goalComplete
+                            ? <svg width="10" height="10" viewBox="0 0 10 10" fill="none" stroke="var(--pe-ok)" strokeWidth="1.8" strokeLinecap="round" strokeLinejoin="round"><path d="M1.5 5.5l2.5 2.5 5-5" /></svg>
+                            : <svg width="10" height="10" viewBox="0 0 10 10" fill="none" stroke="var(--pe-warn)" strokeWidth="1.8" strokeLinecap="round"><circle cx="5" cy="5" r="3.5" /></svg>
+                          }
+                        </span>
+                      </button>
+                    );
+                  })}
+                </div>
+              </div>
+            )}
+
+            {/* Script preview */}
+            <div className="pe-d-section" style={{ paddingTop: 10 }}>
+              <div className="pe-d-section-hd">
+                <span className="pe-d-section-label" style={{ display: 'flex', alignItems: 'center', gap: 4 }}>
+                  Proof script
+                  {!isProofComplete && appliedTactics.length > 0 && (
+                    <span style={{ fontSize: 9.5, color: 'var(--pe-faint)', fontWeight: 400, marginLeft: 2 }}>(partial)</span>
+                  )}
+                </span>
+                {scriptText && (
+                  <button
+                    onClick={handleCopyScript}
+                    className="pe-hist-copy-btn"
+                    title="Copy script to clipboard"
+                  >
+                    {scriptCopied ? (
+                      <>
+                        <svg width="10" height="10" viewBox="0 0 10 10" fill="none" stroke="var(--pe-ok)" strokeWidth="1.8" strokeLinecap="round" strokeLinejoin="round">
+                          <path d="M1.5 5.5l2.5 2.5 5-5" />
+                        </svg>
+                        Copied
+                      </>
+                    ) : (
+                      <>
+                        <svg width="10" height="10" viewBox="0 0 10 10" fill="none" stroke="currentColor" strokeWidth="1.5" strokeLinecap="round" strokeLinejoin="round">
+                          <rect x="3.5" y="3.5" width="5" height="5" rx="1" />
+                          <path d="M6.5 3.5V2.5a1 1 0 0 0-1-1h-3a1 1 0 0 0-1 1v3a1 1 0 0 0 1 1h1" />
+                        </svg>
+                        Copy
+                      </>
+                    )}
+                  </button>
+                )}
+              </div>
+              {scriptText ? (
+                <pre className={`pe-script-block${isProofComplete ? ' complete' : ''}`}>{scriptText}</pre>
+              ) : (
+                <p style={{ fontSize: 11.5, color: 'var(--pe-faint)', fontStyle: 'italic', margin: 0 }}>
+                  Apply tactics to see the proof script build up here.
+                </p>
+              )}
+            </div>
+          </>
+        )}
+
+      </div>
+    </>
+  );
+}
+
+function ContextItem({ entry, kind, isSelected, onClick }: {
+  entry: GlobalEntry; kind: 'def' | 'thm' | 'claim'; isSelected: boolean; onClick: () => void;
+}) {
+  return (
+    <div className={`pe-d-row${isSelected ? ' active' : ''}`} onClick={onClick}>
+      <span className={`pe-kindtag ${kind}`}>{kind}</span>
+      <span className="pe-d-name">{entry.name}</span>
+      <span className="pe-d-type" title={entry.type}>{entry.type}</span>
+    </div>
+  );
 }

--- a/web-react/src/shared/styles/globals.css
+++ b/web-react/src/shared/styles/globals.css
@@ -2,6 +2,7 @@
 @tailwind components;
 @tailwind utilities;
 
+/* ============ SHADCN / TAILWIND TOKENS ============ */
 :root {
   --background: 0 0% 100%;
   --foreground: 222.2 84% 4.9%;
@@ -25,6 +26,38 @@
   --radius: 0.5rem;
 }
 
+/* ============ PIE EDITOR DESIGN TOKENS ============ */
+:root {
+  --pe-bg: #f7f7f5;
+  --pe-surface: #ffffff;
+  --pe-surface-2: #fbfbf9;
+  --pe-surface-sunk: #f2f2ee;
+  --pe-ink: #111418;
+  --pe-ink-2: #3a4049;
+  --pe-muted: #6b7280;
+  --pe-faint: #9aa0a6;
+  --pe-line: #e7e5df;
+  --pe-line-2: #edece6;
+  --pe-accent: oklch(0.54 0.14 255);
+  --pe-accent-soft: oklch(0.96 0.025 255);
+  --pe-ok: #0f8a5a;
+  --pe-ok-soft: #e7f5ed;
+  --pe-warn: #b4770f;
+  --pe-warn-soft: #fbf1d9;
+  --pe-err: #c6334b;
+  --pe-err-soft: #fbe8ec;
+  --pe-goal-pending: #c97400;
+  --pe-goal-current: #b4770f;
+  --pe-goal-complete: #0f8a5a;
+  --pe-tactic: #4363c7;
+  --pe-ui-font: 'Inter', -apple-system, BlinkMacSystemFont, 'Segoe UI', system-ui, sans-serif;
+  --pe-mono-font: 'JetBrains Mono', ui-monospace, SFMono-Regular, Menlo, Consolas, monospace;
+  --pe-radius: 6px;
+  --pe-radius-lg: 10px;
+  --pe-shadow-sm: 0 1px 0 rgba(17, 20, 24, 0.04);
+  --pe-shadow-md: 0 1px 2px rgba(17, 20, 24, 0.06), 0 4px 12px rgba(17, 20, 24, 0.04);
+}
+
 @layer base {
   * {
     @apply border-border;
@@ -32,5 +65,1287 @@
 
   body {
     @apply bg-background text-foreground;
+    font-family: var(--pe-ui-font);
+    font-size: 13px;
+    -webkit-font-smoothing: antialiased;
   }
+}
+
+/* ============ PIE EDITOR LAYOUT ============ */
+.pe-app {
+  display: grid;
+  grid-template-rows: 44px 1fr;
+  height: 100vh;
+  width: 100vw;
+  background: var(--pe-bg);
+  color: var(--pe-ink);
+  font-family: var(--pe-ui-font);
+  font-size: 13px;
+  line-height: 1.45;
+}
+
+/* ============ TOP BAR ============ */
+.pe-topbar {
+  display: flex;
+  align-items: center;
+  gap: 14px;
+  padding: 0 14px;
+  background: var(--pe-surface);
+  border-bottom: 1px solid var(--pe-line);
+  min-width: 0;
+  overflow: hidden;
+}
+
+.pe-sep {
+  width: 1px;
+  height: 18px;
+  background: var(--pe-line);
+  flex-shrink: 0;
+}
+
+.pe-brand {
+  display: flex;
+  align-items: center;
+  gap: 8px;
+  font-weight: 600;
+  letter-spacing: -0.2px;
+  flex-shrink: 0;
+}
+
+.pe-brand-pi {
+  display: inline-flex;
+  width: 22px;
+  height: 22px;
+  align-items: center;
+  justify-content: center;
+  background: var(--pe-ink);
+  color: #fff;
+  border-radius: 5px;
+  font-family: var(--pe-mono-font);
+  font-weight: 600;
+  font-size: 13px;
+}
+
+.pe-brand-name {
+  font-size: 13px;
+  color: var(--pe-ink);
+}
+
+.pe-brand-sub {
+  color: var(--pe-faint);
+  font-weight: 400;
+  font-size: 12px;
+}
+
+.pe-tb-label {
+  font-size: 11.5px;
+  color: var(--pe-muted);
+  flex-shrink: 0;
+}
+
+.pe-select {
+  appearance: none;
+  background: var(--pe-surface);
+  border: 1px solid var(--pe-line);
+  border-radius: 5px;
+  padding: 3px 22px 3px 8px;
+  font-size: 12px;
+  font-family: var(--pe-ui-font);
+  color: var(--pe-ink);
+  cursor: pointer;
+  background-image: url("data:image/svg+xml;utf8,<svg xmlns='http://www.w3.org/2000/svg' width='10' height='10' viewBox='0 0 10 10' fill='none' stroke='%236b7280' stroke-width='1.6'><path d='M2 4l3 3 3-3'/></svg>");
+  background-repeat: no-repeat;
+  background-position: right 6px center;
+}
+
+.pe-select:focus {
+  outline: none;
+  border-color: var(--pe-accent);
+  box-shadow: 0 0 0 3px color-mix(in oklab, var(--pe-accent) 18%, transparent);
+}
+
+.pe-session-chip {
+  display: inline-flex;
+  align-items: center;
+  gap: 7px;
+  padding: 3px 9px;
+  border: 1px solid var(--pe-line);
+  border-radius: 99px;
+  font-size: 11.5px;
+  background: var(--pe-surface);
+  max-width: 360px;
+  min-width: 0;
+  overflow: hidden;
+  white-space: nowrap;
+}
+
+.pe-session-chip > * {
+  flex-shrink: 0;
+}
+
+.pe-session-chip .chip-expr {
+  min-width: 0;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  flex-shrink: 1;
+  color: var(--pe-muted);
+  font-family: var(--pe-mono-font);
+  font-size: 11px;
+}
+
+.pe-session-chip .chip-dot {
+  width: 6px;
+  height: 6px;
+  border-radius: 3px;
+  background: var(--pe-ok);
+}
+
+.pe-session-chip .chip-claim {
+  font-family: var(--pe-mono-font);
+  font-weight: 500;
+  color: var(--pe-ink);
+}
+
+.pe-session-chip .chip-muted {
+  color: var(--pe-muted);
+}
+
+.pe-auto-indicator {
+  display: inline-flex;
+  align-items: center;
+  gap: 7px;
+  font-size: 11.5px;
+  color: var(--pe-muted);
+  padding: 3px 10px;
+  border-radius: 99px;
+  background: var(--pe-surface-2);
+  border: 1px solid var(--pe-line-2);
+  flex-shrink: 0;
+}
+
+.pe-pulse {
+  width: 6px;
+  height: 6px;
+  border-radius: 3px;
+  background: var(--pe-ok);
+  box-shadow: 0 0 0 0 color-mix(in oklab, var(--pe-ok) 50%, transparent);
+  animation: pe-pulse 2s ease-out infinite;
+}
+
+@keyframes pe-pulse {
+  0% { box-shadow: 0 0 0 0 color-mix(in oklab, var(--pe-ok) 45%, transparent); }
+  70% { box-shadow: 0 0 0 6px transparent; }
+  100% { box-shadow: 0 0 0 0 transparent; }
+}
+
+.pe-tb-right {
+  display: flex;
+  align-items: center;
+  gap: 8px;
+  margin-left: auto;
+  flex-shrink: 0;
+}
+
+.pe-error-pill {
+  display: inline-flex;
+  align-items: center;
+  gap: 6px;
+  padding: 3px 10px;
+  border-radius: 99px;
+  font-size: 11.5px;
+  background: var(--pe-err-soft);
+  color: var(--pe-err);
+  border: 1px solid #f5c9d1;
+}
+
+/* ============ MAIN GRID ============ */
+.pe-main {
+  display: grid;
+  grid-template-columns: 340px 170px minmax(0, 1fr) 260px;
+  min-height: 0;
+  background: var(--pe-bg);
+  overflow: hidden;
+}
+
+.pe-main > section {
+  min-width: 0;
+  min-height: 0;
+  display: flex;
+  flex-direction: column;
+  overflow: hidden;
+}
+
+.pe-main.source-collapsed {
+  grid-template-columns: 20px 170px minmax(0, 1fr) 260px;
+}
+
+.pe-main.source-collapsed > section.pe-source {
+  display: none;
+}
+
+@media (max-width: 1240px) {
+  .pe-main { grid-template-columns: 300px 160px minmax(0, 1fr) 240px; }
+  .pe-main.source-collapsed { grid-template-columns: 20px 160px minmax(0, 1fr) 240px; }
+}
+
+@media (max-width: 1100px) {
+  .pe-main { grid-template-columns: 20px 160px minmax(0, 1fr) 240px; }
+  .pe-main > section.pe-source { display: none; }
+  .pe-source-stub { display: flex !important; }
+}
+
+@media (max-width: 900px) {
+  .pe-main { grid-template-columns: 36px 160px minmax(0, 1fr); }
+  .pe-main.source-collapsed { grid-template-columns: 36px 160px minmax(0, 1fr); }
+  .pe-main > section.pe-detail { display: none; }
+}
+
+/* ============ SOURCE STUB ============ */
+.pe-source-stub {
+  display: none;
+  background: var(--pe-surface);
+  border-right: 1px solid var(--pe-line);
+  padding: 0;
+  cursor: pointer;
+  color: var(--pe-muted);
+  flex-direction: column;
+  align-items: center;
+  justify-content: flex-start;
+  gap: 0;
+  min-width: 0;
+  border: none;
+  width: 20px;
+  /* top padding matches panel-head height so icon lands at same y as < button */
+  padding-top: 9px;
+}
+
+.pe-source-stub:hover {
+  background: var(--pe-surface-2);
+  color: var(--pe-ink);
+}
+
+.pe-main.source-collapsed > .pe-source-stub {
+  display: flex;
+}
+
+.pe-stub-label {
+  writing-mode: vertical-rl;
+  transform: rotate(180deg);
+  font-size: 11px;
+  font-weight: 500;
+  letter-spacing: 0.04em;
+  margin-top: 2px;
+}
+
+.pe-stub-sync {
+  margin-top: auto;
+}
+
+/* ============ SHARED PANEL PARTS ============ */
+.pe-panel-head {
+  display: flex;
+  align-items: center;
+  gap: 10px;
+  padding: 9px 14px;
+  border-bottom: 1px solid var(--pe-line-2);
+  background: var(--pe-surface);
+  flex-shrink: 0;
+}
+
+.pe-panel-head h3 {
+  margin: 0;
+  font-size: 12px;
+  font-weight: 600;
+  letter-spacing: -0.1px;
+  color: var(--pe-ink);
+}
+
+.pe-icon-btn {
+  width: 26px;
+  height: 26px;
+  border-radius: 5px;
+  border: 1px solid var(--pe-line);
+  background: var(--pe-surface);
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  color: var(--pe-muted);
+  cursor: pointer;
+  flex-shrink: 0;
+  padding: 0;
+}
+
+.pe-icon-btn:hover {
+  color: var(--pe-ink);
+  background: var(--pe-surface-2);
+}
+
+.pe-btn {
+  border: 1px solid var(--pe-line);
+  background: var(--pe-surface);
+  color: var(--pe-ink);
+  border-radius: 5px;
+  padding: 4px 10px;
+  font-size: 12px;
+  font-family: var(--pe-ui-font);
+  cursor: pointer;
+  display: inline-flex;
+  align-items: center;
+  gap: 6px;
+}
+
+.pe-btn:hover {
+  background: var(--pe-surface-2);
+}
+
+.pe-btn.primary {
+  background: var(--pe-ink);
+  color: #fff;
+  border-color: var(--pe-ink);
+}
+
+.pe-btn.primary:hover {
+  background: #222831;
+}
+
+.pe-btn:disabled {
+  opacity: 0.4;
+  cursor: not-allowed;
+}
+
+/* ============ SOURCE RAIL ============ */
+.pe-source {
+  background: var(--pe-surface);
+  border-right: 1px solid var(--pe-line);
+}
+
+.pe-sync-badge {
+  display: inline-flex;
+  align-items: center;
+  gap: 6px;
+  padding: 2px 8px;
+  border-radius: 99px;
+  font-size: 11px;
+  font-weight: 500;
+  background: var(--pe-ok-soft);
+  color: var(--pe-ok);
+  border: 1px solid #c8e6d4;
+}
+
+.pe-sync-badge .dot {
+  width: 5px;
+  height: 5px;
+  border-radius: 3px;
+  background: currentColor;
+}
+
+.pe-sync-badge.syncing {
+  background: var(--pe-accent-soft);
+  color: var(--pe-accent);
+  border-color: #c9d6f3;
+}
+
+.pe-sync-badge.edited {
+  background: var(--pe-warn-soft);
+  color: var(--pe-warn);
+  border-color: #eed8a7;
+}
+
+.pe-sync-badge.error {
+  background: var(--pe-err-soft);
+  color: var(--pe-err);
+  border-color: #f5c9d1;
+}
+
+.pe-source-claim {
+  display: flex;
+  align-items: center;
+  gap: 8px;
+  padding: 8px 14px;
+  border-bottom: 1px solid var(--pe-line-2);
+  background: var(--pe-surface-2);
+  flex-shrink: 0;
+}
+
+.pe-source-claim label {
+  font-size: 11px;
+  color: var(--pe-muted);
+  flex-shrink: 0;
+}
+
+.pe-input {
+  flex: 1;
+  border: 1px solid var(--pe-line);
+  background: var(--pe-surface);
+  border-radius: 5px;
+  padding: 4px 8px;
+  font-size: 12.5px;
+  font-family: var(--pe-mono-font);
+  color: var(--pe-ink);
+  min-width: 0;
+}
+
+.pe-input:focus {
+  outline: none;
+  border-color: var(--pe-accent);
+  box-shadow: 0 0 0 3px color-mix(in oklab, var(--pe-accent) 18%, transparent);
+}
+
+.pe-editor-frame {
+  flex: 1;
+  display: flex;
+  flex-direction: column;
+  min-height: 0;
+  background: #1b1d22;
+  position: relative;
+}
+
+.pe-gutter-info {
+  position: absolute;
+  top: 8px;
+  right: 10px;
+  font-family: var(--pe-mono-font);
+  font-size: 10.5px;
+  color: #6b7280;
+  z-index: 2;
+  pointer-events: none;
+}
+
+.pe-diag-strip {
+  border-top: 1px solid var(--pe-line);
+  background: var(--pe-surface);
+  max-height: 140px;
+  overflow: auto;
+  flex-shrink: 0;
+}
+
+.pe-diag-head {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  padding: 7px 14px;
+  border-bottom: 1px solid var(--pe-line-2);
+}
+
+.pe-diag-head .title {
+  font-size: 11px;
+  color: var(--pe-muted);
+  display: flex;
+  align-items: center;
+  gap: 8px;
+}
+
+.pe-diag-ok {
+  padding: 9px 14px;
+  font-size: 11.5px;
+  color: var(--pe-ok);
+  display: flex;
+  align-items: center;
+  gap: 7px;
+}
+
+.pe-diag-ok .dot {
+  width: 6px;
+  height: 6px;
+  border-radius: 3px;
+  background: var(--pe-ok);
+}
+
+.pe-diag-list {
+  list-style: none;
+  margin: 0;
+  padding: 2px 0;
+}
+
+.pe-diag-row {
+  display: grid;
+  grid-template-columns: 12px 44px 1fr;
+  gap: 10px;
+  align-items: start;
+  padding: 4px 14px;
+  font-size: 11.5px;
+}
+
+.pe-diag-row:hover {
+  background: var(--pe-surface-2);
+}
+
+.pe-diag-row .sev {
+  width: 8px;
+  height: 8px;
+  border-radius: 4px;
+  margin-top: 4px;
+}
+
+.pe-diag-row.err .sev { background: var(--pe-err); }
+.pe-diag-row.warn .sev { background: var(--pe-warn); }
+
+.pe-diag-row .loc {
+  font-family: var(--pe-mono-font);
+  color: var(--pe-muted);
+  font-size: 11px;
+}
+
+.pe-diag-row .msg {
+  font-family: var(--pe-mono-font);
+  color: var(--pe-ink-2);
+}
+
+.pe-diag-row.err .msg { color: var(--pe-err); }
+
+/* ============ TACTIC RAIL ============ */
+.pe-tactics {
+  background: var(--pe-surface);
+  border-right: 1px solid var(--pe-line);
+}
+
+.pe-tactics-body {
+  flex: 1;
+  overflow: auto;
+  padding: 8px 10px;
+}
+
+.pe-t-cat {
+  margin-bottom: 12px;
+}
+
+.pe-t-cat-head {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  padding: 4px 4px 6px;
+  border-bottom: 1px solid var(--pe-line-2);
+  margin-bottom: 6px;
+}
+
+.pe-t-cat-head .label {
+  font-size: 10.5px;
+  letter-spacing: 0.08em;
+  text-transform: uppercase;
+  color: var(--pe-faint);
+  font-weight: 600;
+}
+
+.pe-t-cat-head .count {
+  font-family: var(--pe-mono-font);
+  font-size: 10.5px;
+  color: var(--pe-faint);
+}
+
+.pe-t-item {
+  display: grid;
+  grid-template-columns: 20px 1fr auto;
+  gap: 8px;
+  align-items: center;
+  padding: 5px 6px;
+  border-radius: 5px;
+  cursor: grab;
+  border: 1px solid transparent;
+  user-select: none;
+}
+
+.pe-t-item:hover {
+  background: var(--pe-surface-2);
+  border-color: var(--pe-line-2);
+}
+
+.pe-t-item:active {
+  cursor: grabbing;
+}
+
+.pe-t-glyph {
+  width: 20px;
+  height: 20px;
+  border-radius: 4px;
+  background: var(--pe-surface-sunk);
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  font-family: var(--pe-mono-font);
+  font-weight: 600;
+  font-size: 11px;
+  color: var(--pe-ink-2);
+  border: 1px solid var(--pe-line-2);
+  flex-shrink: 0;
+}
+
+/* Category colours for glyph badges */
+.pe-t-glyph.cat-introduction {
+  background: #eff6ff;
+  color: #2563eb;
+  border-color: #bfdbfe;
+}
+.pe-t-glyph.cat-constructor {
+  background: #f0fdf4;
+  color: #16a34a;
+  border-color: #bbf7d0;
+}
+.pe-t-glyph.cat-elimination {
+  background: #faf5ff;
+  color: #7c3aed;
+  border-color: #e9d5ff;
+}
+.pe-t-glyph.cat-application {
+  background: #fff7ed;
+  color: #ea580c;
+  border-color: #fed7aa;
+}
+.pe-t-glyph.cat-placeholder {
+  background: #f8fafc;
+  color: #64748b;
+  border-color: #cbd5e1;
+}
+
+.pe-t-nm {
+  font-family: var(--pe-mono-font);
+  font-size: 12px;
+  color: var(--pe-ink);
+  white-space: nowrap;
+  overflow: hidden;
+  text-overflow: ellipsis;
+}
+
+.pe-t-tag {
+  font-size: 9.5px;
+  color: var(--pe-faint);
+  font-family: var(--pe-mono-font);
+  padding: 1px 5px;
+  border: 1px solid var(--pe-line-2);
+  border-radius: 99px;
+  white-space: nowrap;
+}
+
+.pe-t-item:hover .pe-t-tag {
+  color: var(--pe-muted);
+}
+
+/* ============ CANVAS ============ */
+.pe-canvas-wrap {
+  background: var(--pe-bg);
+  position: relative;
+  display: flex;
+  flex-direction: column;
+}
+
+.pe-canvas-head {
+  display: flex;
+  align-items: center;
+  gap: 10px;
+  padding: 8px 14px;
+  background: var(--pe-surface);
+  border-bottom: 1px solid var(--pe-line);
+  min-width: 0;
+  overflow: hidden;
+  flex-shrink: 0;
+}
+
+.pe-breadcrumb {
+  font-family: var(--pe-mono-font);
+  font-size: 11.5px;
+  color: var(--pe-muted);
+  display: flex;
+  align-items: center;
+  gap: 6px;
+  min-width: 0;
+  overflow: hidden;
+  white-space: nowrap;
+  flex-shrink: 1;
+}
+
+.pe-breadcrumb > * { flex-shrink: 0; }
+
+.pe-breadcrumb .cur {
+  overflow: hidden;
+  text-overflow: ellipsis;
+  flex-shrink: 1;
+  color: var(--pe-ink);
+  font-weight: 500;
+}
+
+.pe-canvas-actions {
+  display: flex;
+  align-items: center;
+  gap: 4px;
+}
+
+.pe-canvas-status {
+  display: flex;
+  align-items: center;
+  gap: 14px;
+  padding: 5px 14px;
+  background: var(--pe-surface);
+  border-top: 1px solid var(--pe-line);
+  font-family: var(--pe-mono-font);
+  font-size: 11px;
+  color: var(--pe-muted);
+  flex-shrink: 0;
+}
+
+.pe-cs-item {
+  display: inline-flex;
+  align-items: center;
+  gap: 5px;
+}
+
+.pe-cs-dot {
+  width: 5px;
+  height: 5px;
+  border-radius: 3px;
+  background: var(--pe-ok);
+}
+
+/* ============ DETAIL RAIL ============ */
+.pe-detail {
+  background: var(--pe-surface);
+  border-left: 1px solid var(--pe-line);
+}
+
+.pe-detail-tabs {
+  display: flex;
+  gap: 0;
+  border-bottom: 1px solid var(--pe-line);
+  background: var(--pe-surface);
+  flex-shrink: 0;
+}
+
+.pe-detail-tab {
+  flex: 1;
+  background: transparent;
+  border: none;
+  border-bottom: 2px solid transparent;
+  padding: 9px 8px;
+  font-size: 11.5px;
+  font-family: var(--pe-ui-font);
+  color: var(--pe-muted);
+  cursor: pointer;
+  letter-spacing: 0.02em;
+}
+
+.pe-detail-tab.active {
+  color: var(--pe-ink);
+  border-bottom-color: var(--pe-accent);
+  font-weight: 500;
+}
+
+.pe-detail-tab:hover:not(.active) {
+  color: var(--pe-ink-2);
+  background: var(--pe-surface-2);
+}
+
+.pe-detail-body {
+  flex: 1;
+  overflow: auto;
+}
+
+.pe-d-section {
+  padding: 12px 14px;
+  border-bottom: 1px solid var(--pe-line-2);
+}
+
+.pe-d-section:last-child {
+  border-bottom: none;
+}
+
+.pe-d-section-hd {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  margin-bottom: 8px;
+}
+
+.pe-d-section-label {
+  font-size: 10.5px;
+  letter-spacing: 0.08em;
+  text-transform: uppercase;
+  color: var(--pe-faint);
+  font-weight: 600;
+}
+
+.pe-d-section-count {
+  font-family: var(--pe-mono-font);
+  font-size: 10.5px;
+  color: var(--pe-faint);
+}
+
+.pe-big-type {
+  font-family: var(--pe-mono-font);
+  font-size: 13px;
+  background: var(--pe-surface-sunk);
+  border: 1px solid var(--pe-line-2);
+  border-radius: 6px;
+  padding: 10px 12px;
+  color: var(--pe-ink);
+  line-height: 1.5;
+  word-break: break-word;
+}
+
+.pe-meta {
+  display: flex;
+  gap: 14px;
+  margin-top: 10px;
+  font-size: 11.5px;
+  color: var(--pe-muted);
+}
+
+.pe-meta b {
+  color: var(--pe-ink);
+  font-weight: 500;
+}
+
+.pe-suggested {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 6px;
+}
+
+.pe-chip {
+  font-family: var(--pe-mono-font);
+  font-size: 11px;
+  padding: 3px 9px;
+  background: var(--pe-surface-2);
+  border: 1px solid var(--pe-line);
+  border-radius: 99px;
+  color: var(--pe-ink);
+  cursor: pointer;
+  white-space: nowrap;
+}
+
+.pe-chip:hover {
+  border-color: var(--pe-accent);
+  color: var(--pe-accent);
+}
+
+.pe-d-row {
+  display: flex;
+  align-items: center;
+  gap: 8px;
+  padding: 4px 6px;
+  border-radius: 5px;
+  cursor: pointer;
+}
+
+.pe-d-row:hover {
+  background: var(--pe-surface-2);
+}
+
+.pe-d-row.active {
+  background: var(--pe-accent-soft);
+}
+
+.pe-kindtag {
+  font-family: var(--pe-mono-font);
+  font-size: 9.5px;
+  padding: 1px 5px;
+  border-radius: 3px;
+  background: var(--pe-surface-sunk);
+  color: var(--pe-muted);
+  border: 1px solid var(--pe-line-2);
+  flex-shrink: 0;
+}
+
+.pe-kindtag.def {
+  color: #7b3ff2;
+  background: #f3edfd;
+  border-color: #e2d5f9;
+}
+
+.pe-kindtag.thm {
+  color: var(--pe-ok);
+  background: var(--pe-ok-soft);
+  border-color: #c8e6d4;
+}
+
+.pe-kindtag.claim {
+  color: var(--pe-warn);
+  background: var(--pe-warn-soft);
+  border-color: #eed8a7;
+}
+
+.pe-d-name {
+  font-family: var(--pe-mono-font);
+  font-size: 12px;
+  color: var(--pe-ink);
+}
+
+.pe-d-type {
+  font-family: var(--pe-mono-font);
+  font-size: 10.5px;
+  color: var(--pe-faint);
+  margin-left: auto;
+  max-width: 100px;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}
+
+.pe-ctx-row {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  background: var(--pe-surface);
+  border: 1px solid var(--pe-line-2);
+  border-radius: 5px;
+  padding: 4px 8px;
+  margin-bottom: 4px;
+  font-family: var(--pe-mono-font);
+  font-size: 11.5px;
+}
+
+.pe-ctx-row:last-child {
+  margin-bottom: 0;
+}
+
+.pe-ctx-var {
+  color: var(--pe-accent);
+  font-weight: 600;
+}
+
+.pe-ctx-type {
+  color: var(--pe-muted);
+}
+
+/* ============ AI SETTINGS MODAL ============ */
+.pe-modal-overlay {
+  position: fixed;
+  inset: 0;
+  background: rgba(17, 20, 24, 0.4);
+  z-index: 40;
+  display: flex;
+  align-items: flex-start;
+  justify-content: flex-end;
+  padding: 54px 14px 0;
+}
+
+.pe-modal-panel {
+  background: var(--pe-surface);
+  border: 1px solid var(--pe-line);
+  border-radius: var(--pe-radius-lg);
+  box-shadow: 0 16px 48px rgba(17, 20, 24, 0.14);
+  width: 320px;
+  overflow: hidden;
+}
+
+.pe-modal-head {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  padding: 12px 16px;
+  border-bottom: 1px solid var(--pe-line-2);
+}
+
+.pe-modal-head h3 {
+  margin: 0;
+  font-size: 13px;
+  font-weight: 600;
+}
+
+.pe-modal-body {
+  padding: 12px 16px;
+}
+
+/* ============ PHASE CHIP (topbar) ============ */
+.pe-phase-chip {
+  display: inline-flex;
+  align-items: center;
+  gap: 7px;
+  padding: 3px 9px;
+  border: 1px solid var(--pe-line);
+  border-radius: 99px;
+  font-size: 11.5px;
+  background: var(--pe-surface);
+  flex-shrink: 0;
+}
+
+.pe-phase-chip .chip-dot {
+  width: 6px;
+  height: 6px;
+  border-radius: 3px;
+  background: var(--pe-faint);
+}
+
+.pe-phase-chip .chip-label {
+  color: var(--pe-muted);
+  font-weight: 500;
+}
+
+.pe-phase-chip .chip-claim {
+  font-family: var(--pe-mono-font);
+  font-weight: 500;
+  color: var(--pe-ink);
+  max-width: 180px;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}
+
+/* Authoring — gray/neutral */
+.pe-phase-chip--authoring .chip-dot { background: var(--pe-faint); }
+.pe-phase-chip--authoring .chip-label { color: var(--pe-muted); }
+
+/* Proving — amber */
+.pe-phase-chip--proving {
+  background: var(--pe-warn-soft);
+  border-color: #eed8a7;
+}
+.pe-phase-chip--proving .chip-dot { background: var(--pe-warn); }
+.pe-phase-chip--proving .chip-label { color: var(--pe-warn); }
+
+/* Completed — green */
+.pe-phase-chip--completed {
+  background: var(--pe-ok-soft);
+  border-color: #c8e6d4;
+}
+.pe-phase-chip--completed .chip-dot { background: var(--pe-ok); }
+.pe-phase-chip--completed .chip-label { color: var(--pe-ok); }
+
+/* ============ PHASE BANNER (source panel) ============ */
+.pe-phase-banner {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 10px;
+  padding: 7px 14px;
+  border-bottom: 1px solid transparent;
+  flex-shrink: 0;
+  font-size: 12px;
+}
+
+.pe-phase-banner-left {
+  display: flex;
+  align-items: center;
+  gap: 7px;
+  min-width: 0;
+  overflow: hidden;
+}
+
+.pe-phase-banner-left code {
+  font-family: var(--pe-mono-font);
+  font-size: 11px;
+  font-weight: 600;
+}
+
+.pe-phase-banner--proving {
+  background: var(--pe-warn-soft);
+  border-color: #eed8a7;
+  color: var(--pe-warn);
+}
+
+.pe-phase-banner--completed {
+  background: var(--pe-ok-soft);
+  border-color: #c8e6d4;
+  color: var(--pe-ok);
+}
+
+/* ============ TACTIC RAIL hidden state ============ */
+.pe-tactics--hidden {
+  pointer-events: none;
+  opacity: 0.3;
+  filter: grayscale(0.5);
+  user-select: none;
+}
+
+/* ============ CANVAS DIM OVERLAY ============ */
+.pe-canvas-dim {
+  position: absolute;
+  inset: 0;
+  background: rgba(247, 247, 245, 0.82);
+  backdrop-filter: blur(2px);
+  z-index: 10;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  pointer-events: none;
+}
+
+.pe-canvas-dim-card {
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  gap: 12px;
+  padding: 24px 32px;
+  background: var(--pe-surface);
+  border: 1px solid var(--pe-line);
+  border-radius: var(--pe-radius-lg);
+  box-shadow: var(--pe-shadow-md);
+  color: var(--pe-muted);
+  text-align: center;
+  max-width: 280px;
+}
+
+.pe-canvas-dim-card p {
+  margin: 0;
+  font-size: 12.5px;
+  line-height: 1.5;
+  color: var(--pe-muted);
+}
+
+.pe-canvas-dim-card strong {
+  color: var(--pe-ink);
+}
+
+/* ============ CONFIRM MODAL ============ */
+.pe-confirm-modal {
+  background: var(--pe-surface);
+  border: 1px solid var(--pe-line);
+  border-radius: var(--pe-radius-lg);
+  box-shadow: 0 16px 48px rgba(17, 20, 24, 0.18);
+  padding: 20px 24px;
+  width: 320px;
+}
+
+.pe-confirm-modal h4 {
+  margin: 0 0 8px;
+  font-size: 14px;
+  font-weight: 600;
+  color: var(--pe-ink);
+}
+
+.pe-confirm-modal p {
+  margin: 0 0 16px;
+  font-size: 12.5px;
+  color: var(--pe-muted);
+  line-height: 1.5;
+}
+
+.pe-confirm-actions {
+  display: flex;
+  justify-content: flex-end;
+  gap: 8px;
+}
+
+/* ============ HISTORY TAB — PROGRESS BAR ============ */
+.pe-hist-progress {
+  display: flex;
+  flex-direction: column;
+  gap: 5px;
+  padding: 10px 14px 8px;
+  border-bottom: 1px solid var(--pe-line-2);
+  flex-shrink: 0;
+}
+
+.pe-hist-progress-bar {
+  height: 4px;
+  border-radius: 99px;
+  background: var(--pe-line);
+  overflow: hidden;
+}
+
+.pe-hist-progress-fill {
+  height: 100%;
+  border-radius: 99px;
+  background: var(--pe-ok);
+  transition: width 0.3s ease;
+}
+
+.pe-hist-progress-label {
+  font-size: 11.5px;
+  color: var(--pe-muted);
+}
+
+/* ============ HISTORY TAB — STEP ROWS ============ */
+.pe-hist-steps {
+  display: flex;
+  flex-direction: column;
+  gap: 0;
+}
+
+.pe-hist-row {
+  display: grid;
+  grid-template-columns: 18px 8px 1fr auto 14px;
+  align-items: center;
+  gap: 7px;
+  padding: 6px 6px;
+  border-radius: 5px;
+  cursor: pointer;
+  width: 100%;
+  text-align: left;
+  background: none;
+  border: none;
+  font-family: var(--pe-ui-font);
+}
+
+.pe-hist-row:hover {
+  background: var(--pe-surface-2);
+}
+
+.pe-hist-num {
+  font-size: 10px;
+  color: var(--pe-faint);
+  font-family: var(--pe-mono-font);
+  text-align: right;
+  flex-shrink: 0;
+}
+
+.pe-hist-dot {
+  width: 7px;
+  height: 7px;
+  border-radius: 50%;
+  flex-shrink: 0;
+}
+
+.pe-hist-name {
+  font-family: var(--pe-mono-font);
+  font-size: 12px;
+  font-weight: 600;
+  white-space: nowrap;
+  overflow: hidden;
+  text-overflow: ellipsis;
+}
+
+.pe-hist-goal {
+  font-family: var(--pe-mono-font);
+  font-size: 10px;
+  color: var(--pe-faint);
+  white-space: nowrap;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  text-align: right;
+  max-width: 90px;
+}
+
+.pe-hist-result {
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  flex-shrink: 0;
+}
+
+/* ============ HISTORY TAB — SCRIPT BLOCK ============ */
+.pe-hist-copy-btn {
+  display: inline-flex;
+  align-items: center;
+  gap: 4px;
+  font-size: 10.5px;
+  padding: 2px 8px;
+  border-radius: 4px;
+  background: var(--pe-surface-sunk);
+  color: var(--pe-muted);
+  border: 1px solid var(--pe-line-2);
+  cursor: pointer;
+  font-family: var(--pe-ui-font);
+}
+
+.pe-hist-copy-btn:hover {
+  background: var(--pe-surface-2);
+  color: var(--pe-ink);
+}
+
+.pe-script-block {
+  margin: 0;
+  padding: 10px 12px;
+  background: var(--pe-surface-sunk);
+  border: 1px solid var(--pe-line-2);
+  border-radius: 6px;
+  font-family: var(--pe-mono-font);
+  font-size: 11px;
+  color: var(--pe-ink-2);
+  line-height: 1.6;
+  white-space: pre;
+  overflow-x: auto;
+  word-break: normal;
+}
+
+.pe-script-block.complete {
+  border-color: color-mix(in oklab, var(--pe-ok) 25%, var(--pe-line));
+  background: color-mix(in oklab, var(--pe-ok) 4%, var(--pe-surface));
 }


### PR DESCRIPTION
## Summary

Redesigns the History tab in `DetailPanel` as a proof journal: shows proof progress, applied tactic steps, and a live-generated proof script.

## What this PR does

- Replaces the old `DetailPanel` tab layout with a structured proof journal
- **Progress section**: open goals count, applied tactics count, completion percentage bar
- **Steps section**: chronological list of applied tactics with goal context
- **Script section**: live-generated Pie proof script (auto-updates as tactics are applied)
- Adds new CSS rules to `globals.css` for journal layout

## Files changed

| File | Change |
|------|--------|
| `web-react/src/features/proof-editor/components/panels/DetailPanel.tsx` | Full rewrite as proof journal |
| `web-react/src/shared/styles/globals.css` | Journal layout styles |

## Merge order

**Depends on:** #174, #172, #187. Merge after all three.

**Depended on by:** #191.

Recommended merge order: **`#174 → #172 → #188 → #187 → #190 → #191`**

## Conflict resolution (merge this after #174 + #172 + #187)

When merging #190 onto the previous three, **2 files will conflict**:

### `web-react/src/features/proof-editor/components/panels/DetailPanel.tsx`

**Resolution: take `#190` (incoming/theirs).**

`#190`'s DetailPanel is the full 536-line proof journal. The current HEAD has `#174`'s 254-line version. Take `#190` entirely:

```bash
git checkout --theirs \
  web-react/src/features/proof-editor/components/panels/DetailPanel.tsx
```

### `web-react/src/shared/styles/globals.css`

**Resolution: take `#190` (incoming/theirs).**

Both HEAD and `#190` have grown `globals.css` (with aesthetics styles from `#174` and journal styles from `#190` respectively). `#190`'s version already includes the aesthetics CSS and adds journal rules on top:

```bash
git checkout --theirs \
  web-react/src/shared/styles/globals.css
```

Then commit:

```bash
git add -A
git commit -m "Merge #190 feat/history-panel"
```

## AI Declaration

This implementation was designed and generated with the assistance of **Claude (Sonnet 4.6)** by Anthropic.